### PR TITLE
[ch26406] Feature: UMD bundle

### DIFF
--- a/packages/api-client/.gitignore
+++ b/packages/api-client/.gitignore
@@ -2,4 +2,5 @@
 .DS_Store
 node_modules
 dist
+umd
 coverage/

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -16,6 +16,7 @@
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
     "module": "dist/api-client.esm.js",
+    "browser": "dist/opendatasoft.apiclient.umd.development.js",
     "files": [
         "dist",
         "src"
@@ -25,7 +26,7 @@
     },
     "scripts": {
         "watch": "tsdx watch --verbose",
-        "build": "tsdx build",
+        "build": "tsdx build --format cjs,esm,umd --name 'opendatasoft.apiClient'",
         "docs": "typedoc",
         "test": "tsdx test",
         "lint": "tsdx lint src test",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -16,10 +16,11 @@
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
     "module": "dist/api-client.esm.js",
-    "browser": "dist/opendatasoft.apiclient.umd.js",
+    "browser": "umd/opendatasoft.apiclient.umd.js",
     "files": [
         "dist",
-        "src"
+        "src",
+        "umd"
     ],
     "engines": {
         "node": ">=10"

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -16,7 +16,7 @@
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
     "module": "dist/api-client.esm.js",
-    "browser": "dist/opendatasoft.apiclient.umd.development.js",
+    "browser": "dist/opendatasoft.apiclient.umd.production.js",
     "files": [
         "dist",
         "src"

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -16,7 +16,7 @@
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
     "module": "dist/api-client.esm.js",
-    "browser": "dist/opendatasoft.apiclient.umd.production.js",
+    "browser": "dist/opendatasoft.apiclient.umd.js",
     "files": [
         "dist",
         "src"

--- a/packages/api-client/src/client/index.ts
+++ b/packages/api-client/src/client/index.ts
@@ -5,6 +5,12 @@ import { ApiResponse } from './types';
 
 const API_KEY_AUTH_TYPE = 'ApiKey';
 
+// Using the UMD bundle in ObservableHQ, the error "ReferenceError: global is not defined" is returned.
+// ... I'm not sure why it behaves that way, but this fixes the issue:
+const _global: any = typeof global !== "undefined" ? global :
+    typeof self !== "undefined" ? self :
+    typeof window !== "undefined" ? window : {};
+
 export type RequestInterceptor = (request: Request) => Promise<Request>;
 export type ResponseInterceptor = (response: Response) => Promise<ApiResponse>;
 
@@ -31,7 +37,7 @@ export class ApiClient {
      * Constructs an instance of {@link ApiClient}
      */
     constructor(options?: ApiClientOptions) {
-        const fetch = options?.fetch || global?.fetch;
+        const fetch = options?.fetch || _global?.fetch;
 
         if (!fetch) {
             throw new Error(
@@ -39,7 +45,7 @@ export class ApiClient {
             );
         }
 
-        const domain = options?.domain || global?.location?.origin;
+        const domain = options?.domain || _global?.location?.origin;
         if (!domain) {
             throw new Error('Missing domain');
         }

--- a/packages/api-client/tsdx.config.js
+++ b/packages/api-client/tsdx.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    rollup(config, options) {
+        // This configuration allows 'immutability-helper' to be included in the UMD bundle.
+        // Related issue: https://github.com/formium/tsdx/issues/179
+        if (config.output.format === 'umd') {
+          delete config.external;
+        }
+        return config;
+    }
+};

--- a/packages/api-client/tsdx.config.js
+++ b/packages/api-client/tsdx.config.js
@@ -1,9 +1,15 @@
 module.exports = {
-    rollup(config, options) {
+    rollup(config) {
         // This configuration allows 'immutability-helper' to be included in the UMD bundle.
         // Related issue: https://github.com/formium/tsdx/issues/179
         if (config.output.format === 'umd') {
-          delete config.external;
+            delete config.external;
+            config.output = {
+                    name: 'opendatasoft.apiClient',
+                    file: __dirname + '/dist/umd/opendatasoft.apiclient.umd.js',
+                    name: 'opendatasoft.apiClient',
+                    format: 'umd'
+            }
         }
         return config;
     }

--- a/packages/api-client/tsdx.config.js
+++ b/packages/api-client/tsdx.config.js
@@ -6,7 +6,7 @@ module.exports = {
             delete config.external;
             config.output = {
                     name: 'opendatasoft.apiClient',
-                    file: __dirname + '/dist/umd/opendatasoft.apiclient.umd.js',
+                    file: __dirname + '/umd/opendatasoft.apiclient.umd.js',
                     name: 'opendatasoft.apiClient',
                     format: 'umd'
             }


### PR DESCRIPTION
The goal of this PR is to be able to use the API Client in the ObservableHQ website. To do so, it is [necessary to propose a UMD bundle](https://observablehq.com/@observablehq/how-to-require-stubborn-modules).

I've made a test in ObservableHQ [here](https://observablehq.com/@wmai/testing-opentdatasoft-api-client). The bundles are exposed from my local environment using Ngrok.

I believe that it will be necessary to manually access the UMD bundle using the CDN **UNPKG** ([UNPKG `@opendatasoft/api-client`](https://unpkg.com/browse/@opendatasoft/api-client@0.0.2/)).

If we publish this version on npm, the right way to require the module on ObservableHQ will be:
```javascript
myModule = require(`(https://unpkg.com/browse/@opendatasoft/api-client@0.0.3/dist/umd/opendatasoft.apiclient.umd.js`)
```

Ressources:
- [ObservableHQ - Introduction to require](https://observablehq.com/@observablehq/introduction-to-require)
- [ObservableHQ - How to require stubborn modules](https://observablehq.com/@observablehq/how-to-require-stubborn-modules)
- [UNPKG](https://unpkg.com/) 