### PR TITLE
[ch26407] Doc: use immutable dataset in documentation

### DIFF
--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -45,7 +45,7 @@ const query = fromCatalog() // From the domain catalog
     .dataset("doc-geonames-cities-5000") // ... we'll use the dataset "doc-geonames-cities-5000"
     .aggregates() // ... in order to make an aggregation.
     .where("country_code:'FR'") // // Filter records where country_code === "FR".
-    .groupBy("name, population") // Select the fields "name" and "population".
+    .groupBy("name as city, population") // Select the fields "name" and "population".
     .orderBy("-population") // Sort by population in descending order.
     .limit(10) // But we only want the first 10 most populated cities.
     .toString(); // Then finally, we convert our query into a string.

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -38,14 +38,14 @@ Here is a quick example to get you started:
 import { ApiClient, fromCatalog } from '@opendatasoft/api-client';
 
 // Initialize the Client by indicating the domain to request.
-const client = new ApiClient({ domain: "public" });
+const client = new ApiClient({ domain: "documentation-resources" });
 
 // Create the query to run.
 const query = fromCatalog() // From the domain catalog
-    .dataset("worldcitiespop") // ... we'll use the dataset "worldcitiespop"
+    .dataset("doc-geonames-cities-5000") // ... we'll use the dataset "doc-geonames-cities-5000"
     .aggregates() // ... in order to make an aggregation.
-    .where("country:'fr'") // // Filter records where country === "fr".
-    .groupBy("city, population") // Select the fields "city" and "population".
+    .where("country_code:'FR'") // // Filter records where country_code === "FR".
+    .groupBy("name, population") // Select the fields "name" and "population".
     .orderBy("-population") // Sort by population in descending order.
     .limit(10) // But we only want the first 10 most populated cities.
     .toString(); // Then finally, we convert our query into a string.

--- a/packages/api-client/tsdx.config.js
+++ b/packages/api-client/tsdx.config.js
@@ -5,10 +5,10 @@ module.exports = {
         if (config.output.format === 'umd') {
             delete config.external;
             config.output = {
-                    name: 'opendatasoft.apiClient',
-                    file: __dirname + '/umd/opendatasoft.apiclient.umd.js',
-                    name: 'opendatasoft.apiClient',
-                    format: 'umd'
+                name: 'opendatasoft.apiClient',
+                file: __dirname + '/umd/opendatasoft.apiclient.umd.js',
+                name: 'opendatasoft.apiClient',
+                format: 'umd'
             }
         }
         return config;


### PR DESCRIPTION
The example in the README.md of the Client API, we use the public domain, this is not reliable, we should use `documentation-resources` instead.

[This dataset](https://documentation-resources.opendatasoft.com/explore/dataset/doc-geonames-cities-5000/table/) seems to be a perfect fit.

Related ticket [here](https://app.clubhouse.io/opendatasoft/story/26407/as-a-developer-i-need-to-use-immutable-datasets-in-the-documentation-in-order-to-have-reliable-results).

The [CodeSandbox sample](https://codesandbox.io/s/api-clientget-started-be0xu?file=/src/index.js) has been updated as well.