### PR TITLE
Catch errors within ReactImpl to avoid higher-level violent crashes

### DIFF
--- a/packages/visualizations-react/src/components/ReactImpl.tsx
+++ b/packages/visualizations-react/src/components/ReactImpl.tsx
@@ -1,5 +1,5 @@
 import { Async, BaseComponent } from '@opendatasoft/visualizations';
-import React, { FC, ForwardedRef, forwardRef, useEffect, useRef } from 'react';
+import React, { FC, ForwardedRef, forwardRef, useEffect, useRef, useState } from 'react';
 import { useMergeRefs } from 'use-callback-ref';
 import { Props } from './Props';
 
@@ -19,25 +19,50 @@ export function wrap<Data, Options, ComponentClass extends BaseComponent<Data, O
         const { tag, data, options, ...elementProps } = props;
         const componentRef = useRef<ComponentClass | null>(null);
         const containerRef = useRef<HTMLElement | null>(null);
+        const [error, setError] = useState<Boolean>(false);
 
         // Update data
         useEffect(() => {
-            componentRef.current?.updateData(data);
-        }, [data]);
+            if (!error) {
+                try {
+                    componentRef.current?.updateData(data);
+                } catch (exception) {
+                    console.error(exception);
+                    setError(true);
+                }
+            }
+        }, [data, error]);
 
         // Update options
         useEffect(() => {
-            componentRef.current?.updateOptions(options);
-        }, [options]);
+            if (!error) {
+                try {
+                    componentRef.current?.updateOptions(options);
+                } catch (exception) {
+                    console.error(exception);
+                    setError(true);
+                }
+            }
+        }, [options, error]);
 
         // Create and destroy
         useEffect(() => {
             const container = containerRef.current;
             if (container) {
-                const component = new ComponentConstructor(container, data, options);
-                componentRef.current = component;
+                let component: (ComponentClass | null) = null;
+                if (!error) {
+                    try {
+                        component = new ComponentConstructor(container, data, options);
+                        componentRef.current = component;
+                    } catch (exception) {
+                        console.error(exception);
+                        setError(true);
+                    }
+                }
                 return () => {
-                    component.destroy();
+                    if (component) {
+                        component.destroy();
+                    }
                     componentRef.current = null;
                 };
             } else {
@@ -45,12 +70,27 @@ export function wrap<Data, Options, ComponentClass extends BaseComponent<Data, O
                     'Container was expected to be available in useEffect. This is a bug.'
                 );
             }
-        }, [tag]);
+        }, [tag, error]);
+
+        const mergedRef = useMergeRefs([containerRef, ref]);
 
         // With React 17 we should be able to just use jsx runtime.
+        const children = error ?
+            React.createElement('div', {
+                style: {
+                    backgroundColor: '#f2dede',
+                    color: '#a94442',
+                    height: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    textAlign: 'center',
+                },
+            }, "An error occurred while rendering the component") :
+            null;
+
         return React.createElement(tag || 'div', {
             ...elementProps, // such as style...
-            ref: useMergeRefs([containerRef, ref]), // Merging ref so caller can use it
-        });
+            ref: mergedRef, // Merging ref so caller can use it
+        }, children);
     });
 }

--- a/packages/visualizations-react/src/components/ReactImpl.tsx
+++ b/packages/visualizations-react/src/components/ReactImpl.tsx
@@ -82,10 +82,15 @@ export function wrap<Data, Options, ComponentClass extends BaseComponent<Data, O
                     color: '#a94442',
                     height: '100%',
                     display: 'flex',
+                    flexDirection: 'column',
                     alignItems: 'center',
+                    justifyContent: 'center',
                     textAlign: 'center',
                 },
-            }, "An error occurred while rendering the component") :
+            }, "An error occurred while rendering the component",
+                React.createElement("button", {
+                    onClick: () => setError(false),
+                }, "Try again")) :
             null;
 
         return React.createElement(tag || 'div', {


### PR DESCRIPTION
After running into fan-blowing, infinite-looping errors within our interfaces, I quickly built some system to render an "error!" block instead of just letting the error bubble up, and still try to render it again the next time. I'm not sure if we should handle the error block itself within the integration (translations, styling...), but the catching itself should happen there I think, as I don't think it's trivial to catch it up properly within the app (unless ErrorBoundary does the trick, including stopping rendering loops, I'm not entirely familiar with it yet). It's still very crude but it seems to save me a lot of time whenever I get a crash 😅