### PR TITLE
Support `maintainAspectRatio` in chart options

### DIFF
--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -104,6 +104,7 @@
         chartConfig.type = defaultValue(options.series[0]?.type, 'line'); // Will set chartJs default value accordingly
         let chartOptions = chartConfig.options || {};
         chartOptions.aspectRatio = options.aspectRatio;
+        chartOptions.maintainAspectRatio = options.maintainAspectRatio;
         chartOptions.scales = {};
         if (options.xAxis) {
             chartOptions.scales['x'] = {

--- a/packages/visualizations/src/components/types.ts
+++ b/packages/visualizations/src/components/types.ts
@@ -5,6 +5,8 @@ export interface ChartOptions {
     series: ChartSeries[];
     /** Chart aspect ratio */
     aspectRatio?: number;
+    /** Maintain aspect ratio when the canvas is resized */
+    maintainAspectRatio?: boolean;
     /** Configure xAxis */
     xAxis?: CartesianAxisConfiguration;
     /** Configure default yAxis */


### PR DESCRIPTION
Since we support `aspectRatio` already, I added `maintainAspectRatio` in the same way.

This is very much passing straight ChartJS options, but I don't think it's too much of an issue considering all the drawing part is very much depending on ChartJS's specific implementation anyway; it seems alright to expose its properties straight away and rely on its official documentation on this part.