### PR TITLE
Fix refresh bug on the pie charts lines custom plugin

### DIFF
--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -15,7 +15,6 @@
         CartesianAxisConfiguration,
     } from '../types';
     import { compactStringOrNumber } from '../../utils';
-    import pieDataLabelsPlugin from './pieDataLabelsPlugin';
 
     export let data: Async<DataFrame>;
     export let options: ChartOptions;
@@ -384,10 +383,6 @@
             },
         };
         chartConfig.options = chartOptions;
-
-        if (series[0].type === 'pie' && series[0].dataLabels?.display) {
-            chartConfig?.plugins?.push(pieDataLabelsPlugin);
-        }
     }
 
     $: {

--- a/packages/visualizations/src/components/Chart/index.ts
+++ b/packages/visualizations/src/components/Chart/index.ts
@@ -3,9 +3,11 @@ import ChartDataLabels from 'chartjs-plugin-datalabels';
 import type { ChartOptions, DataFrame } from '../types';
 import ChartImpl from './Chart.svelte';
 import SvelteImpl from '../SvelteImpl';
+import pieDataLabelsPlugin from './pieDataLabelsPlugin';
 
 ChartJs.Chart.register(...ChartJs.registerables);
 ChartJs.Chart.register(ChartDataLabels);
+ChartJs.Chart.register(pieDataLabelsPlugin);
 
 // Export ChartJS to allow reusing instance and changing default, use case not supported
 // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle

--- a/packages/visualizations/src/components/Chart/pieDataLabelsPlugin.ts
+++ b/packages/visualizations/src/components/Chart/pieDataLabelsPlugin.ts
@@ -4,60 +4,63 @@ import type { Plugin } from 'chart.js';
 const pieDataLabelsPlugin: Plugin<'pie'> = {
     id: 'ods-chartjs-plugin-datalabels',
     afterDraw: (chart) => {
-        const { ctx } = chart;
-        ctx.save();
+        const { type } = chart.config;
+        const { datalabels } = chart.config.data.datasets?.[0];
+        if (type === 'pie' && datalabels?.display) {
+            const { ctx } = chart;
+            ctx.save();
+            const chartCenterPoint = {
+                x: (chart.chartArea.right - chart.chartArea.left) / 2 + chart.chartArea.left,
+                y: (chart.chartArea.bottom - chart.chartArea.top) / 2 + chart.chartArea.top,
+            };
 
-        const chartCenterPoint = {
-            x: (chart.chartArea.right - chart.chartArea.left) / 2 + chart.chartArea.left,
-            y: (chart.chartArea.bottom - chart.chartArea.top) / 2 + chart.chartArea.top,
-        };
+            const { labels, datasets } = chart.config.data;
+            // FIXME: There seems to be a problem with the `Color` type of ChartJS, originally, the `Color` type allowed
+            // ... string[] but not anymore (we should write an issue on their repo).
+            const backgroundColor = datasets[0]?.backgroundColor as string[] | undefined;
 
-        const { labels, datasets } = chart.config.data;
-        // FIXME: There seems to be a problem with the `Color` type of ChartJS, originally, the `Color` type allowed
-        // ... string[] but not anymore (we should write an issue on their repo).
-        const backgroundColor = datasets[0]?.backgroundColor as string[] | undefined;
+            labels?.forEach((_, i) => {
+                // FIXME: Why do we have to use `as any` instead of `as ArcElement` to type `acr`, even tho
+                // ... `arc instanceof ArcElement` returns true?
+                const arc = chart.getDatasetMeta(0).data[i] as any;
 
-        labels?.forEach((_, i) => {
-            // FIXME: Why do we have to use `as any` instead of `as ArcElement` to type `acr`, even tho
-            // ... `arc instanceof ArcElement` returns true?
-            const arc = chart.getDatasetMeta(0).data[i] as any;
+                // Get the center of the chart and the center point of the slice to determine the angle
+                const centerPoint = arc.getCenterPoint();
 
-            // Get the center of the chart and the center point of the slice to determine the angle
-            const centerPoint = arc.getCenterPoint();
+                const angle = Math.atan2(
+                    centerPoint.y - chartCenterPoint.y,
+                    centerPoint.x - chartCenterPoint.x
+                );
 
-            const angle = Math.atan2(
-                centerPoint.y - chartCenterPoint.y,
-                centerPoint.x - chartCenterPoint.x
-            );
+                // Check for offset on datalabels
+                let datalabelsOffset = 0;
+                // FIXME: As warn by chartjs-plugin-datalabels, we should not access private properties or methods starting
+                // ... with `$` or `_`.  The implementation can change at any version and could break.
+                if (arc.$datalabels[0]._model?.offset) {
+                    datalabelsOffset = arc.$datalabels[0]._model.offset;
+                }
 
-            // Check for offset on datalabels
-            let datalabelsOffset = 0;
-            // FIXME: As warn by chartjs-plugin-datalabels, we should not access private properties or methods starting
-            // ... with `$` or `_`.  The implementation can change at any version and could break.
-            if (arc.$datalabels[0]._model?.offset) {
-                datalabelsOffset = arc.$datalabels[0]._model.offset;
-            }
+                // Get a first drawing point
+                const point1X = chartCenterPoint.x + Math.cos(angle) * (arc.outerRadius - 8);
+                const point1Y = chartCenterPoint.y + Math.sin(angle) * (arc.outerRadius - 8);
+                // Get the second point depending of its position
+                const point2X =
+                    chartCenterPoint.x + Math.cos(angle) * (arc.outerRadius + 4 + datalabelsOffset);
+                const point2Y =
+                    chartCenterPoint.y + Math.sin(angle) * (arc.outerRadius + 4 + datalabelsOffset);
 
-            // Get a first drawing point
-            const point1X = chartCenterPoint.x + Math.cos(angle) * (arc.outerRadius - 8);
-            const point1Y = chartCenterPoint.y + Math.sin(angle) * (arc.outerRadius - 8);
-            // Get the second point depending of its position
-            const point2X =
-                chartCenterPoint.x + Math.cos(angle) * (arc.outerRadius + 4 + datalabelsOffset);
-            const point2Y =
-                chartCenterPoint.y + Math.sin(angle) * (arc.outerRadius + 4 + datalabelsOffset);
-
-            // Draw line between center of the slice and label
-            if (backgroundColor?.[i]) {
-                ctx.strokeStyle = backgroundColor[i];
-            }
-            ctx.beginPath();
-            ctx.lineWidth = 2;
-            ctx.moveTo(point1X, point1Y);
-            ctx.lineTo(point2X, point2Y);
-            ctx.stroke();
-        });
-        ctx.restore();
+                // Draw line between center of the slice and label
+                if (backgroundColor?.[i]) {
+                    ctx.strokeStyle = backgroundColor[i];
+                }
+                ctx.beginPath();
+                ctx.lineWidth = 2;
+                ctx.moveTo(point1X, point1Y);
+                ctx.lineTo(point2X, point2Y);
+                ctx.stroke();
+            });
+            ctx.restore();
+        }
     },
 };
 


### PR DESCRIPTION
### The goal for this PR is to :

- Correct a bug noticed on the studio while changing the pie charts layouts. The custom plugin drawing lines was still applied until next page refresh (chartJS re-render). Registering the plugin globally and applying it only conditionally seems to resolve the observed bug.