### PR TITLE
Disable charts animations

### DIFF
--- a/packages/visualizations-react/.storybook/preview.js
+++ b/packages/visualizations-react/.storybook/preview.js
@@ -7,8 +7,3 @@ export const parameters = {
     // https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args
     actions: { argTypesRegex: '^on.*' },
 };
-
-// Disable ChartJs animation for UI testing
-if (isChromatic()) {
-    _ChartJs.defaults.animation = false;
-}

--- a/packages/visualizations/src/components/Chart/index.ts
+++ b/packages/visualizations/src/components/Chart/index.ts
@@ -3,11 +3,13 @@ import ChartDataLabels from 'chartjs-plugin-datalabels';
 import type { ChartOptions, DataFrame } from '../types';
 import ChartImpl from './Chart.svelte';
 import SvelteImpl from '../SvelteImpl';
-import pieDataLabelsPlugin from './pieDataLabelsPlugin';
+import PieDataLabelsPlugin from './pieDataLabelsPlugin';
 
 ChartJs.Chart.register(...ChartJs.registerables);
 ChartJs.Chart.register(ChartDataLabels);
-ChartJs.Chart.register(pieDataLabelsPlugin);
+ChartJs.Chart.register(PieDataLabelsPlugin);
+
+ChartJs.defaults.animation = false;
 
 // Export ChartJS to allow reusing instance and changing default, use case not supported
 // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle


### PR DESCRIPTION
The purpose of this PR is to disable all chart animations.

In the future, we can imagine proposing an option to activate or not the animations in a global way at the SDK level or by component. The question is still pending.