### PR TITLE
MarkdownText: Display all lists as tight lists

### DIFF
--- a/packages/visualizations/src/components/MarkdownText/MarkdownText.svelte
+++ b/packages/visualizations/src/components/MarkdownText/MarkdownText.svelte
@@ -1,10 +1,37 @@
 <script lang="ts" context="module">
     import MarkdownIt from 'markdown-it';
     import MarkdownItMark from 'markdown-it-mark';
+    import type StateCore from 'markdown-it/lib/rules_core/state_core';
     import type { MarkdownTextOptions } from '../types';
     import type { Async } from '../../types';
 
-    const md = new MarkdownIt('zero').use(MarkdownItMark).enable([
+    // This MarkdownIt plugin enforces lists to be displayed as tight, because we only want to support them
+    // at the moment.
+    function tightLists(md: MarkdownIt) {
+        md.core.ruler.after('inline', 'all-tight-lists', (state: StateCore) => {
+            let withinParagraph = false;
+
+            // In order to display lists as tight, we need to hide paragraphs before MarkdownIt renders then.
+            // https://github.com/markdown-it/markdown-it/issues/678#issuecomment-637895300
+            state.tokens.forEach((token) => {
+                if (token.type === 'list_item_open') {
+                    withinParagraph = true;
+                } else if (token.type === 'list_item_close') {
+                    withinParagraph = false;
+                } else if (
+                    withinParagraph &&
+                    (token.type === 'paragraph_open' || token.type === 'paragraph_close')
+                ) {
+                    // eslint-disable-next-line no-param-reassign
+                    token.hidden = true;
+                }
+            });
+
+            return true;
+        });
+    }
+
+    const md = new MarkdownIt('zero').use(MarkdownItMark).use(tightLists).enable([
         'hr',
         'list',
         'heading',


### PR DESCRIPTION
We only want to support tight lists, despite Markdown supporting both tight lists and loose lists.

This PR introduces a small plugin that makes it so MarkdownIt always renders tight lists, even if the initial parsing created a loose one (which is indicated by list items containing non-hidden paragraphs).