### PR TITLE
fix(MarkdownText): Don't display escape characters

### DIFF
--- a/packages/visualizations-react/test/MarkdownText.test.tsx
+++ b/packages/visualizations-react/test/MarkdownText.test.tsx
@@ -39,4 +39,12 @@ describe('MarkdownText', () => {
         // Strikethrough
         getByText('~~strikethrough~~');
     });
+
+    it("doesn't display escape characters", () => {
+        const value = 'Hi there \\*\\*world\\*\\*';
+
+        const { getByText } = render(<MarkdownText options={{}} data={{ value }} />);
+
+        getByText('Hi there **world**');
+    });
 });

--- a/packages/visualizations/src/components/MarkdownText/MarkdownText.svelte
+++ b/packages/visualizations/src/components/MarkdownText/MarkdownText.svelte
@@ -10,6 +10,7 @@
         'heading',
         'emphasis', // bold & italic
         'link',
+        'escape',
     ]);
 </script>
 


### PR DESCRIPTION
This PR makes sure that if you pass MarkdownText content like this:
```
\*\*I shouldn't be bold!\*\*

\# I'm a hashtag, not a title
```
The characters are properly escaped and displayed, without showing the `\`, or interpreting the token as Markdown syntax.