### PR TITLE
Create an error state to catch untracked errors from Svelte to React

### DIFF
--- a/packages/visualizations-react/src/components/ReactImpl.tsx
+++ b/packages/visualizations-react/src/components/ReactImpl.tsx
@@ -59,14 +59,10 @@ export function wrap<Data, Options, ComponentClass extends BaseComponent<Data, O
         useEffect(() => {
             const container = containerRef.current;
             if (container) {
-                const component = new ComponentConstructor(
-                    container,
-                    initialState.data,
-                    {
-                        ...initialState.options,
-                        setOnError,
-                    },
-                );
+                const component = new ComponentConstructor(container, initialState.data, {
+                    ...initialState.options,
+                    setOnError,
+                });
                 componentRef.current = component;
                 return () => {
                     component.destroy();

--- a/packages/visualizations-react/src/components/ReactImpl.tsx
+++ b/packages/visualizations-react/src/components/ReactImpl.tsx
@@ -27,6 +27,16 @@ export function wrap<Data, Options, ComponentClass extends BaseComponent<Data, O
         });
         const [lastTag, setLastTag] = useState(tag);
 
+        // Throw errors coming from Svelte that cannot be caught by react error boundary
+        // FIXME: a better solution would be to implement a global error boundary in svelte when it will be available
+        const [onError, setOnError] = useState<string | null>(null);
+
+        useEffect(() => {
+            if (onError) {
+                throw onError;
+            }
+        }, [onError]);
+
         // Update data (put before creating the component to skip the initial render)
         useEffect(() => {
             componentRef.current?.updateData(data);
@@ -52,7 +62,10 @@ export function wrap<Data, Options, ComponentClass extends BaseComponent<Data, O
                 const component = new ComponentConstructor(
                     container,
                     initialState.data,
-                    initialState.options
+                    {
+                        ...initialState.options,
+                        setOnError,
+                    },
                 );
                 componentRef.current = component;
                 return () => {

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -22,8 +22,8 @@
     function tryCreateChart(ctx: CanvasRenderingContext2D, config: ChartConfiguration) {
         try {
             return new Chart(ctx, config);
-        } catch (err) {
-            setOnError?.(JSON.stringify(err));
+        } catch (err: any) {
+            setOnError?.(err.toString());
             return undefined;
         }
     }
@@ -37,15 +37,15 @@
             update() {
                 try {
                     chart?.update();
-                } catch (err) {
-                    setOnError?.(JSON.stringify(err));
+                } catch (err: any) {
+                    setOnError?.(err.toString());
                 }
             },
             destroy() {
                 try {
                     chart?.destroy();
-                } catch (err) {
-                    setOnError?.(JSON.stringify(err));
+                } catch (err: any) {
+                    setOnError?.(err.toString());
                 }
             },
         };

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -15,14 +15,16 @@
 
     let dataFrame: DataFrame = [];
     let series: ChartSeries[] = [];
-    let { labelColumn, setOnError } = options;
+    let { labelColumn } = options;
+    const { setOnError } = options;
 
     // Function to handle chart creation errors
     function tryCreateChart(ctx: CanvasRenderingContext2D, config: ChartConfiguration) {
         try {
             return new Chart(ctx, config);
         } catch(err) {
-            setOnError(JSON.stringify(err));
+            setOnError?.(JSON.stringify(err));
+            return undefined;
         }
     }
 
@@ -36,7 +38,7 @@
                 try {
                     chart?.update();
                 } catch(err) {
-                    setOnError(JSON.stringify(err));
+                    setOnError?.(JSON.stringify(err));
                 }
 
             },
@@ -44,7 +46,7 @@
                 try {
                     chart?.destroy();
                 } catch(err) {
-                    setOnError(JSON.stringify(err));
+                    setOnError?.(JSON.stringify(err));
                 }
             },
         };

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -22,7 +22,7 @@
     function tryCreateChart(ctx: CanvasRenderingContext2D, config: ChartConfiguration) {
         try {
             return new Chart(ctx, config);
-        } catch(err) {
+        } catch (err) {
             setOnError?.(JSON.stringify(err));
             return undefined;
         }
@@ -37,15 +37,14 @@
             update() {
                 try {
                     chart?.update();
-                } catch(err) {
+                } catch (err) {
                     setOnError?.(JSON.stringify(err));
                 }
-
             },
             destroy() {
                 try {
                     chart?.destroy();
-                } catch(err) {
+                } catch (err) {
                     setOnError?.(JSON.stringify(err));
                 }
             },

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -15,19 +15,37 @@
 
     let dataFrame: DataFrame = [];
     let series: ChartSeries[] = [];
-    let { labelColumn } = options;
+    let { labelColumn, setOnError } = options;
+
+    // Function to handle chart creation errors
+    function tryCreateChart(ctx: CanvasRenderingContext2D, config: ChartConfiguration) {
+        try {
+            return new Chart(ctx, config);
+        } catch(err) {
+            setOnError(JSON.stringify(err));
+        }
+    }
 
     // Hook to handle chart lifecycle
     function chartJs(node: HTMLCanvasElement, config: ChartConfiguration) {
         const ctx = node.getContext('2d');
         if (!ctx) throw new Error('Failed to get canvas context');
-        const chart = new Chart(ctx, config);
+        const chart: Chart | undefined = tryCreateChart(ctx, config);
         return {
             update() {
-                chart.update();
+                try {
+                    chart?.update();
+                } catch(err) {
+                    setOnError(JSON.stringify(err));
+                }
+
             },
             destroy() {
-                chart.destroy();
+                try {
+                    chart?.destroy();
+                } catch(err) {
+                    setOnError(JSON.stringify(err));
+                }
             },
         };
     }

--- a/packages/visualizations/src/components/types.ts
+++ b/packages/visualizations/src/components/types.ts
@@ -23,6 +23,8 @@ export interface ChartOptions {
     ariaLabel: string;
     /** Link button to source */
     source?: Source;
+    /** Error setter to send error from svelte to react error boundary */
+    setOnError: (error: string) => string;
 }
 
 export interface Source {

--- a/packages/visualizations/src/components/types.ts
+++ b/packages/visualizations/src/components/types.ts
@@ -23,8 +23,8 @@ export interface ChartOptions {
     ariaLabel: string;
     /** Link button to source */
     source?: Source;
-    /** Error setter to send error from svelte to react error boundary */
-    setOnError: (error: string) => string;
+    /** Error setter to send error from svelte to another framework */
+    setOnError?: (error: string) => string;
 }
 
 export interface Source {


### PR DESCRIPTION
**Goal**: The goal for this PR is to create a state in the React implementation to catch and handle untracked errors from Svelte and integrate them into react error boundary. This should be replaced by a global error boundary in Svelte when it will be available.

**Context**: while investigating on a chart update uncaught error (time scales not accepted by the chartjs chart update method), it appeared that the asynchronous code from the update wasn't caught by Svelte neither by React resulting in a uncontrolled crash. Svelte doesn't offer an error boundary solution for now : [github discussion and PR](https://github.com/sveltejs/rfcs/pull/46) and react error boundaries are not handling asynchronous code as well : [react documentation](https://reactjs.org/docs/error-boundaries.html ). It appeared that handling specific risky part of the code by wrapping them into a try and catch and setting an error state might be a solution.

**Open discussion**: this implementation is not ideal as we'll have to add this mechanism specifically for each risky part of the code and gives only a partial safety. A global Svelte error boundary would be better but not yet available. The investigated bug that led to this solution was caused by wrong chartjs parameters sent, we should probably more focus on not allowing this to happen, in this specific case find a solution: chartjs zoom plugin or falling back to a close available time scale. The question is should we keep this error handler as a protection anyway to avoid violent crashes or ignore it and resolve quickly all incoming bugs  ?

If the implementation is accepted, what are the other code part we want to wrap with a try and catch and error state ? The markdown rendering ?