### PR TITLE
Add not helper for ODSQL

### DIFF
--- a/packages/api-client/src/odsql/index.ts
+++ b/packages/api-client/src/odsql/index.ts
@@ -178,4 +178,6 @@ export const one = (...conditions: (string | undefined | null)[]) =>
         .map(condition => `(${condition})`)
         .join(' OR ');
 
+export const not = (condition: (string | undefined | null)) => Boolean(condition) ? `not (${condition})` : null;
+
 export const list = (...values: (string | undefined | null)[]) => values.filter(Boolean).join(',');

--- a/packages/api-client/test/odsql.test.ts
+++ b/packages/api-client/test/odsql.test.ts
@@ -13,6 +13,7 @@ import {
     date,
     all,
     one,
+    not,
     list,
 } from '../src/';
 import { expect, it, describe, test } from '@jest/globals';
@@ -90,6 +91,21 @@ describe('ODSQL query builder', () => {
                     .where(prev => all(prev, searchTerm && `search(${string(searchTerm)})`))
                     .toString()
             ).toEqual('catalog/query/?where=%28search%28%22my+search+term%22%29%29');
+        });
+
+        test('not helper', () => {
+            expect(
+                fromCatalog()
+                    .query()
+                    .where(not('x = 1'))
+                    .toString()
+            ).toEqual('catalog/query/?where=not+%28x+%3D+1%29');
+            expect(
+                fromCatalog()
+                    .query()
+                    .where(not(undefined))
+                    .toString()
+            ).toEqual('catalog/query/');
         });
 
         test('list helper', () => {


### PR DESCRIPTION
The goal of this PR is to a a `not` helper function to build negation in ODSQL, and improves chaining with existing `all` and `one` helpers.

### Example usage
```javascript
# basic usage
fromCatalog()
    .query()
    .where(not('x = 1')
    .toString()

// usage with chaining
fromCatalog()
    .query()
    .where(all(
        one(not('x = 1'), not('x = 3')),
        'x = 2',
    )
    .toString()
```