### PR TITLE
Refactor the calculation of initial bbox

### DIFF
--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script>
+    import turfBbox from '@turf/bbox';
     import MapRender from './MapRender.svelte';
     import { BLANK } from './mapStyles';
     import { colorShapes } from './utils';
@@ -16,6 +17,7 @@
     let shapes;
     let colorScale;
     let aspectRatio;
+    let bbox;
     $: ({ shapes, colorScale, aspectRatio } = options);
 
     // Choropleth is always display over a blank map, for readability purposes
@@ -57,6 +59,8 @@ shapes: {
                     'fill-outline-color': '#fff',
                 },
             };
+
+            bbox = turfBbox(newShapes.geoJson);
         } else {
             console.error('Unknown shapes type', newShapes.type);
         }
@@ -66,7 +70,7 @@ shapes: {
 </script>
 
 <div>
-    <MapRender {style} {source} {layer} {aspectRatio} />
+    <MapRender {style} {source} {layer} {aspectRatio} {bbox} />
 </div>
 
 <style>

--- a/packages/visualizations/src/components/Map/utils.js
+++ b/packages/visualizations/src/components/Map/utils.js
@@ -129,13 +129,3 @@ export const computeMaxZoomFromGeoJsonFeatures = (mapContainer, features) => {
     });
     return maxZoom;
 };
-
-export const getStartingPointForMap = (mapContainer, bbox) =>
-    geoViewport.viewport(
-        bbox,
-        [mapContainer.clientWidth, mapContainer.clientHeight],
-        undefined,
-        undefined,
-        512,
-        true
-    );


### PR DESCRIPTION
Previously we relies on `querySourceFeatures` or `queryRenderedFeatures` to recompute a bbox at the technical level (`MapRender`) regardless of the initial source. Unfortunately, we can only access geometries as they were re-optimized for rendering by Maplibre, meaning they are re-cut, discarded if outside the viewport or too small for the current zoom etc. In other words, we can't use it to access the original source data, so it's really not usable to compute the ideal bbox that represent all the data.

This PR:
- Changes `MapRender` to take a `bbox` parameter, which is not optional. `MapRender` is tasked with the rendering logic only, and it needs that now.
- `Choropleth` computes the bbox from the original GeoJSON data, and passes it to `MapRender`.
- Adds a few TODO where I'm not entirely sure we want to keep the current code. We should discuss this at some point, probably wen we have more real-life tests under our belt.
- I'm not sure yet how we'll deal with Vector Tiles. The cheapest way would be to require the bbox to be  passed alongside the VTiles URL (e.g. the bbox of France for the France cities vector tiles), but that won't work if you're only intereted in parts of the vector tiles (e.g. only the cities around Paris...). The solution may require enforcing the choice of a bbox in the initial configuration, but it's also intertwined with the UI we'd like to provide in the Studio. To be discussed once we're opening the subject I guess.