### PR TITLE
Map option to disable interaction

### DIFF
--- a/packages/visualizations-react/stories/Map/NonInteractiveChoropleth.stories.tsx
+++ b/packages/visualizations-react/stories/Map/NonInteractiveChoropleth.stories.tsx
@@ -2,19 +2,12 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import { Choropleth, Props } from '../../src';
 import { ChoroplethOptions, DataFrame } from '@opendatasoft/visualizations';
-import { IMAGES } from '../utils';
 import { shapes } from './shapes';
 
 const meta: Meta = {
     title: 'Map/Non Interactive Choropleth',
     component: Choropleth,
 };
-
-const df = [
-    { x: 'France', y: 60 },
-    { x: 'Île de France', y: 35 },
-    { x: 'Corsica', y: 95 },
-];
 
 export default meta;
 const Template = (args: Props<DataFrame, ChoroplethOptions>) => (

--- a/packages/visualizations-react/stories/Map/NonInteractiveChoropleth.stories.tsx
+++ b/packages/visualizations-react/stories/Map/NonInteractiveChoropleth.stories.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { Choropleth, Props } from '../../src';
+import { ChoroplethOptions, DataFrame } from '@opendatasoft/visualizations';
+import { IMAGES } from '../utils';
+import { shapes } from './shapes';
+
+const meta: Meta = {
+    title: 'Map/Non Interactive Choropleth',
+    component: Choropleth,
+};
+
+const df = [
+    { x: 'France', y: 60 },
+    { x: 'Île de France', y: 35 },
+    { x: 'Corsica', y: 95 },
+];
+
+export default meta;
+const Template = (args: Props<DataFrame, ChoroplethOptions>) => (
+    <div
+        style={{
+            width: '50%',
+            minHeight: '100px',
+            minWidth: '100px',
+            margin: 'auto',
+            border: '1px solid black',
+        }}
+    >
+        <Choropleth {...args} />
+    </div>
+);
+
+export const NonInteractiveChoropleth = Template.bind({});
+const NonInteractiveChoroplethArgs: Props<DataFrame, ChoroplethOptions> = {
+    data: {
+        loading: false,
+        value: [
+            { x: 'France', y: 60 },
+            { x: 'Île de France', y: 35 },
+            { x: 'Corsica', y: 95 },
+        ],
+    },
+    options: {
+        style: {},
+        parameters: {},
+        shapes,
+        aspectRatio: 1,
+        activeShapes: ['France'],
+        interactive: false,
+    },
+};
+NonInteractiveChoropleth.args = NonInteractiveChoroplethArgs;

--- a/packages/visualizations-react/stories/Map/StudioChoropleth.stories.tsx
+++ b/packages/visualizations-react/stories/Map/StudioChoropleth.stories.tsx
@@ -50,6 +50,25 @@ const StudioChoroplethArgs: Props<DataFrame, ChoroplethOptions> = {
 };
 StudioChoropleth.args = StudioChoroplethArgs;
 
+export const StudioChoroplethEmptyValue = Template.bind({});
+const StudioChoroplethEmptyValueArgs: Props<DataFrame, ChoroplethOptions> = {
+    data: {
+        loading: false,
+        value: [
+            { x: 'France', y: 60 },
+            { x: 'Corsica', y: 95 },
+        ],
+    },
+    options: {
+        style: {},
+        parameters: {},
+        shapes,
+        defaultEmptyValueColor: '#f29d9d',
+        aspectRatio: 1,
+    },
+};
+StudioChoroplethEmptyValue.args = StudioChoroplethEmptyValueArgs;
+
 export const StudioChoroplethGradient = Template.bind({});
 const StudioChoroplethGradientArgs: Props<DataFrame, ChoroplethOptions> = {
     data: {

--- a/packages/visualizations-react/stories/Map/StudioChoropleth.stories.tsx
+++ b/packages/visualizations-react/stories/Map/StudioChoropleth.stories.tsx
@@ -63,7 +63,7 @@ const StudioChoroplethEmptyValueArgs: Props<DataFrame, ChoroplethOptions> = {
         style: {},
         parameters: {},
         shapes,
-        defaultEmptyValueColor: '#f29d9d',
+        emptyValueColor: '#f29d9d',
         aspectRatio: 1,
     },
 };

--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -24,7 +24,15 @@
     let renderTooltip;
     let bbox;
     let activeShapes;
-    $: ({ shapes, colorsScale = defaultColorsScale, legend, aspectRatio, activeShapes } = options);
+    let defaultInteractive = true;
+    $: ({
+        shapes,
+        colorsScale = defaultColorsScale,
+        legend,
+        aspectRatio,
+        activeShapes,
+        interactive = defaultInteractive,
+    } = options);
 
     // Choropleth is always display over a blank map, for readability purposes
     const style = BLANK;
@@ -101,6 +109,7 @@ shapes: {
         {renderTooltip}
         {bbox}
         {activeShapes}
+        {interactive}
     />
 </div>
 

--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -20,13 +20,15 @@
         },
     };
 
+    const defaultEmptyValueColor = '#cccccc';
+
     let aspectRatio;
     let renderTooltip;
     let bbox;
     let activeShapes;
 
     // Used to apply a chosen color for shapes without values (default: #cccccc)
-    let defaultEmptyValueColor;
+    let emptyValueColor;
 
     const defaultInteractive = true;
     $: ({
@@ -36,7 +38,7 @@
         aspectRatio,
         activeShapes,
         interactive = defaultInteractive,
-        defaultEmptyValueColor,
+        emptyValueColor = defaultEmptyValueColor,
     } = options);
 
     // Choropleth is always display over a blank map, for readability purposes
@@ -67,7 +69,7 @@ shapes: {
                 newShapes.geoJson,
                 values,
                 newColorScale,
-                defaultEmptyValueColor
+                emptyValueColor
             );
             const coloredShapes = computeColors.geoJson;
             dataBounds = computeColors.bounds;

--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -58,8 +58,8 @@ shapes: {
     url: ''
 }
 */
-    function computeSourceLayerAndBboxes(values, newShapes, newColorScale) {
-        if ((newShapes.type === 'geojson' && !newShapes.geoJson) || !values) {
+    function computeSourceLayerAndBboxes(values = [], newShapes, newColorScale) {
+        if (newShapes.type === 'geojson' && !newShapes.geoJson) {
             // We don't have everything we need yet
             return;
         }

--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -63,7 +63,12 @@ shapes: {
         }
 
         if (newShapes.type === 'geojson') {
-            const computeColors = colorShapes(newShapes.geoJson, values, newColorScale, defaultEmptyValueColor);
+            const computeColors = colorShapes(
+                newShapes.geoJson,
+                values,
+                newColorScale,
+                defaultEmptyValueColor
+            );
             const coloredShapes = computeColors.geoJson;
             dataBounds = computeColors.bounds;
 

--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -24,7 +24,7 @@
     let renderTooltip;
     let bbox;
     let activeShapes;
-    let defaultInteractive = true;
+    const defaultInteractive = true;
     $: ({
         shapes,
         colorsScale = defaultColorsScale,

--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -24,6 +24,10 @@
     let renderTooltip;
     let bbox;
     let activeShapes;
+
+    // Used to apply a chosen color for shapes without values (default: #cccccc)
+    let defaultEmptyValueColor;
+
     const defaultInteractive = true;
     $: ({
         shapes,
@@ -32,6 +36,7 @@
         aspectRatio,
         activeShapes,
         interactive = defaultInteractive,
+        defaultEmptyValueColor,
     } = options);
 
     // Choropleth is always display over a blank map, for readability purposes
@@ -58,7 +63,7 @@ shapes: {
         }
 
         if (newShapes.type === 'geojson') {
-            const computeColors = colorShapes(newShapes.geoJson, values, newColorScale);
+            const computeColors = colorShapes(newShapes.geoJson, values, newColorScale, defaultEmptyValueColor);
             const coloredShapes = computeColors.geoJson;
             dataBounds = computeColors.bounds;
 

--- a/packages/visualizations/src/components/Map/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/MapRender.svelte
@@ -84,14 +84,8 @@ TODO:
         map = new maplibregl.Map({
             container,
             style,
-            interactive,
             ...start,
         });
-
-        const nav = new maplibregl.NavigationControl();
-        if (interactive) {
-            map.addControl(nav, 'top-left');
-        };
 
         map.on('load', () => {
             mapReady = true;
@@ -202,15 +196,7 @@ TODO:
                 source: sourceId,
             });
 
-            if (interactive) {
-                map.off('mousemove', layerId, addTooltip);
-                map.off('mouseleave', layerId, removeTooltip);
-
-                if (renderTooltip) {
-                    map.on('mousemove', layerId, addTooltip);
-                    map.on('mouseleave', layerId, removeTooltip);
-                }
-            }
+            addInteractivity(interactive);
 
             map.on('sourcedata', sourceLoadingCallback);
         }
@@ -221,6 +207,22 @@ TODO:
             map.setStyle(newStyle);
             // Changing the style resets the map
             map.once('styledata', () => updateSourceAndLayer(source, layer));
+        }
+    }
+
+    function addInteractivity(isInteractive) {
+        map.interactive = isInteractive;
+        if (isInteractive) {
+            const nav = new maplibregl.NavigationControl();
+            map.addControl(nav, 'top-left');
+
+            map.off('mousemove', layerId, addTooltip);
+            map.off('mouseleave', layerId, removeTooltip);
+
+            if (renderTooltip) {
+                map.on('mousemove', layerId, addTooltip);
+                map.on('mouseleave', layerId, removeTooltip);
+            }
         }
     }
 

--- a/packages/visualizations/src/components/Map/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/MapRender.svelte
@@ -54,6 +54,8 @@ TODO:
 
     let container;
     let map;
+    // Used to add navigation control to map
+    let nav;
 
     let mapReady = false;
     // Used to add a listener to resize map on container changes, canceled on destroy
@@ -84,9 +86,10 @@ TODO:
         map = new maplibregl.Map({
             container,
             style,
-            interactive,
             ...start,
         });
+
+        nav = new maplibregl.NavigationControl();
 
         map.on('load', () => {
             mapReady = true;
@@ -197,7 +200,7 @@ TODO:
                 source: sourceId,
             });
 
-            addInteractivity(interactive);
+            handleInteractivity(interactive);
 
             map.on('sourcedata', sourceLoadingCallback);
         }
@@ -211,17 +214,50 @@ TODO:
         }
     }
 
-    function addInteractivity(isInteractive) {
+    function handleInteractivity(isInteractive) {
         if (isInteractive) {
-            const nav = new maplibregl.NavigationControl();
-            map.addControl(nav, 'top-left');
+            // Enable all user interaction handlers
+            // Another way to disable all user handlers is to pass the option interactive = false on map creation
+            // But it doesn't allow to change it afterwards
+            // Id est it forces you to recreate another map if you want to change that option
+            map.boxZoom.enable();
+            map.doubleClickZoom.enable();
+            map.dragPan.enable();
+            map.dragRotate.enable();
+            map.keyboard.enable();
+            map.scrollZoom.enable();
+            map.touchZoomRotate.enable();
 
+            // Add control to map
+            if (!map.hasControl(nav)) {
+                map.addControl(nav, 'top-left');
+            }
+
+            // Handle tooltip display
             map.off('mousemove', layerId, addTooltip);
             map.off('mouseleave', layerId, removeTooltip);
 
             if (renderTooltip) {
                 map.on('mousemove', layerId, addTooltip);
                 map.on('mouseleave', layerId, removeTooltip);
+            }
+        } else {
+            // Disable all user interaction handlers
+            map.boxZoom.disable();
+            map.doubleClickZoom.disable();
+            map.dragPan.disable();
+            map.dragRotate.disable();
+            map.keyboard.disable();
+            map.scrollZoom.disable();
+            map.touchZoomRotate.disable();
+
+            // Remove tooltip
+            map.off('mousemove', layerId, addTooltip);
+            map.off('mouseleave', layerId, removeTooltip);
+
+            // Remove control from map
+            if (map.hasControl(nav)) {
+                map.removeControl(nav, 'top-left');
             }
         }
     }

--- a/packages/visualizations/src/components/Map/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/MapRender.svelte
@@ -25,6 +25,9 @@ TODO:
     // bounding box to start from, and restrict to it
     export let bbox;
 
+    // option to disable map interactions
+    export let interactive;
+
     // options to display legend
     export let legend;
     export let colorsScale;
@@ -81,11 +84,14 @@ TODO:
         map = new maplibregl.Map({
             container,
             style,
+            interactive,
             ...start,
         });
 
         const nav = new maplibregl.NavigationControl();
-        map.addControl(nav, 'top-left');
+        if (interactive) {
+            map.addControl(nav, 'top-left');
+        };
 
         map.on('load', () => {
             mapReady = true;
@@ -196,12 +202,14 @@ TODO:
                 source: sourceId,
             });
 
-            map.off('mousemove', layerId, addTooltip);
-            map.off('mouseleave', layerId, removeTooltip);
+            if (interactive) {
+                map.off('mousemove', layerId, addTooltip);
+                map.off('mouseleave', layerId, removeTooltip);
 
-            if (renderTooltip) {
-                map.on('mousemove', layerId, addTooltip);
-                map.on('mouseleave', layerId, removeTooltip);
+                if (renderTooltip) {
+                    map.on('mousemove', layerId, addTooltip);
+                    map.on('mouseleave', layerId, removeTooltip);
+                }
             }
 
             map.on('sourcedata', sourceLoadingCallback);

--- a/packages/visualizations/src/components/Map/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/MapRender.svelte
@@ -248,8 +248,6 @@ TODO:
                 source: sourceId,
             });
 
-            handleInteractivity(interactive);
-
             map.on('sourcedata', sourceLoadingCallback);
         }
     }
@@ -270,6 +268,10 @@ TODO:
         if (mapReady) {
             updateSourceAndLayer(source, layer);
         }
+    }
+
+    $: if (mapReady) {
+        handleInteractivity(interactive);
     }
 
     $: updateStyle(style);

--- a/packages/visualizations/src/components/Map/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/MapRender.svelte
@@ -183,7 +183,7 @@ TODO:
         hoverPopup.remove();
     }
 
-    function handleInteractivity(isInteractive) {
+    function handleInteractivity(isInteractive, tooltipRenderer) {
         if (isInteractive) {
             // Enable all user interaction handlers
             // Another way to disable all user handlers is to pass the option interactive = false on map creation
@@ -206,7 +206,7 @@ TODO:
             map.off('mousemove', layerId, addTooltip);
             map.off('mouseleave', layerId, removeTooltip);
 
-            if (renderTooltip) {
+            if (tooltipRenderer) {
                 map.on('mousemove', layerId, addTooltip);
                 map.on('mouseleave', layerId, removeTooltip);
             }
@@ -271,9 +271,8 @@ TODO:
     }
 
     $: if (mapReady) {
-        handleInteractivity(interactive);
+        handleInteractivity(interactive, renderTooltip);
     }
-
     $: updateStyle(style);
     $: {
         // Move the map to the bbox if it is set

--- a/packages/visualizations/src/components/Map/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/MapRender.svelte
@@ -183,6 +183,54 @@ TODO:
         hoverPopup.remove();
     }
 
+    function handleInteractivity(isInteractive) {
+        if (isInteractive) {
+            // Enable all user interaction handlers
+            // Another way to disable all user handlers is to pass the option interactive = false on map creation
+            // But it doesn't allow to change it afterwards
+            // Id est it forces you to recreate another map if you want to change that option
+            map.boxZoom.enable();
+            map.doubleClickZoom.enable();
+            map.dragPan.enable();
+            map.dragRotate.enable();
+            map.keyboard.enable();
+            map.scrollZoom.enable();
+            map.touchZoomRotate.enable();
+
+            // Add navigation control to map
+            if (!map.hasControl(nav)) {
+                map.addControl(nav, 'top-left');
+            }
+
+            // Handle tooltip display
+            map.off('mousemove', layerId, addTooltip);
+            map.off('mouseleave', layerId, removeTooltip);
+
+            if (renderTooltip) {
+                map.on('mousemove', layerId, addTooltip);
+                map.on('mouseleave', layerId, removeTooltip);
+            }
+        } else {
+            // Disable all user interaction handlers
+            map.boxZoom.disable();
+            map.doubleClickZoom.disable();
+            map.dragPan.disable();
+            map.dragRotate.disable();
+            map.keyboard.disable();
+            map.scrollZoom.disable();
+            map.touchZoomRotate.disable();
+
+            // Remove tooltip
+            map.off('mousemove', layerId, addTooltip);
+            map.off('mouseleave', layerId, removeTooltip);
+
+            // Remove navigation control from map
+            if (map.hasControl(nav)) {
+                map.removeControl(nav, 'top-left');
+            }
+        }
+    }
+
     function updateSourceAndLayer(newSource, newLayer) {
         if (newSource && newLayer) {
             if (map.getLayer(layerId)) {
@@ -211,54 +259,6 @@ TODO:
             map.setStyle(newStyle);
             // Changing the style resets the map
             map.once('styledata', () => updateSourceAndLayer(source, layer));
-        }
-    }
-
-    function handleInteractivity(isInteractive) {
-        if (isInteractive) {
-            // Enable all user interaction handlers
-            // Another way to disable all user handlers is to pass the option interactive = false on map creation
-            // But it doesn't allow to change it afterwards
-            // Id est it forces you to recreate another map if you want to change that option
-            map.boxZoom.enable();
-            map.doubleClickZoom.enable();
-            map.dragPan.enable();
-            map.dragRotate.enable();
-            map.keyboard.enable();
-            map.scrollZoom.enable();
-            map.touchZoomRotate.enable();
-
-            // Add control to map
-            if (!map.hasControl(nav)) {
-                map.addControl(nav, 'top-left');
-            }
-
-            // Handle tooltip display
-            map.off('mousemove', layerId, addTooltip);
-            map.off('mouseleave', layerId, removeTooltip);
-
-            if (renderTooltip) {
-                map.on('mousemove', layerId, addTooltip);
-                map.on('mouseleave', layerId, removeTooltip);
-            }
-        } else {
-            // Disable all user interaction handlers
-            map.boxZoom.disable();
-            map.doubleClickZoom.disable();
-            map.dragPan.disable();
-            map.dragRotate.disable();
-            map.keyboard.disable();
-            map.scrollZoom.disable();
-            map.touchZoomRotate.disable();
-
-            // Remove tooltip
-            map.off('mousemove', layerId, addTooltip);
-            map.off('mouseleave', layerId, removeTooltip);
-
-            // Remove control from map
-            if (map.hasControl(nav)) {
-                map.removeControl(nav, 'top-left');
-            }
         }
     }
 

--- a/packages/visualizations/src/components/Map/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/MapRender.svelte
@@ -84,6 +84,7 @@ TODO:
         map = new maplibregl.Map({
             container,
             style,
+            interactive,
             ...start,
         });
 
@@ -211,7 +212,6 @@ TODO:
     }
 
     function addInteractivity(isInteractive) {
-        map.interactive = isInteractive;
         if (isInteractive) {
             const nav = new maplibregl.NavigationControl();
             map.addControl(nav, 'top-left');

--- a/packages/visualizations/src/components/Map/utils.js
+++ b/packages/visualizations/src/components/Map/utils.js
@@ -4,7 +4,7 @@ import geoViewport from '@mapbox/geo-viewport';
 export const LIGHT_GREY = '#CBD2DB';
 export const DARK_GREY = '#515457';
 
-export const colorShapes = (geoJson, values, colorsScale, defaultEmptyValueColor) => {
+export const colorShapes = (geoJson, values, colorsScale, emptyValueColor) => {
     // Key in the values is "x"
     // Key in the shapes is "key"
     // We add a color property in the JSON
@@ -43,13 +43,7 @@ export const colorShapes = (geoJson, values, colorsScale, defaultEmptyValueColor
     const coloredFeatures = geoJson.features.map((feature) => {
         const shapeMapping = feature.properties.key;
         const value = dataMapping[shapeMapping]; // FIXME: beware of int/string differences in keys
-        let color;
-        const applyDifferentEmptyValueColor = !value && defaultEmptyValueColor;
-        if (applyDifferentEmptyValueColor) {
-            color = chroma(defaultEmptyValueColor).hex();
-        } else {
-            color = scale(value).hex();
-        }
+        const color = value ? scale(value).hex() : emptyValueColor;
 
         return {
             ...feature,

--- a/packages/visualizations/src/components/Map/utils.js
+++ b/packages/visualizations/src/components/Map/utils.js
@@ -4,7 +4,7 @@ import geoViewport from '@mapbox/geo-viewport';
 export const LIGHT_GREY = '#CBD2DB';
 export const DARK_GREY = '#515457';
 
-export const colorShapes = (geoJson, values, colorsScale) => {
+export const colorShapes = (geoJson, values, colorsScale, defaultEmptyValueColor) => {
     // Key in the values is "x"
     // Key in the shapes is "key"
     // We add a color property in the JSON
@@ -43,7 +43,13 @@ export const colorShapes = (geoJson, values, colorsScale) => {
     const coloredFeatures = geoJson.features.map((feature) => {
         const shapeMapping = feature.properties.key;
         const value = dataMapping[shapeMapping]; // FIXME: beware of int/string differences in keys
-        const color = scale(value).hex();
+        let color;
+        const applyDifferentEmptyValueColor = !value && defaultEmptyValueColor;
+        if (applyDifferentEmptyValueColor) {
+            color = chroma(defaultEmptyValueColor).hex();
+        } else {
+            color = scale(value).hex();
+        }
 
         return {
             ...feature,


### PR DESCRIPTION
The goal for this PR is to add an option for MapRender to enable or disable map interactivity.
Default value should be true as this is the default and normal MapLibre behaviour.

MapLibre gives an interesting option on map creation to easily disable map interactivity `interactive=false` that disables basic user interactions but it is not handling the navigation control panel and our added tooltips.

You can see a possible simple implementation in this [commit](https://github.com/opendatasoft/ods-dataviz-sdk/commit/0575bfb94194c75378eeadbeeb3822b3ea648e81)

The issue with this approach is that this option can't be changed afterwards and if you want to make the map interactive again you will have to create another one...

Finally I chose to handle interactivity both ways and allow a switch to enable or disable map interactivity. This forces to target all user interaction handlers one by one. I'm open for discussion on this point should we keep this heavier implementation but more reactive or should we switch for something lighter like here [commit](https://github.com/opendatasoft/ods-dataviz-sdk/commit/0575bfb94194c75378eeadbeeb3822b3ea648e81) ?

**Also I decided to add an option to change the default #cccccc color for shapes that don't have corresponding values as I guess it's useful to have for design purposes.**