### PR TITLE
Bug/sc-34366/tooltip-doesn-t-display-the-value-in-some

### DIFF
--- a/packages/visualizations/package-lock.json
+++ b/packages/visualizations/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@opendatasoft/visualizations",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "license": "MIT",
             "dependencies": {
                 "@mapbox/geo-viewport": "^0.5.0",
@@ -33,6 +33,7 @@
                 "@rollup/plugin-replace": "^3.0.1",
                 "@rollup/plugin-typescript": "^6.1.0",
                 "@tsconfig/svelte": "^1.0.10",
+                "@types/lodash": "^4.14.182",
                 "@types/luxon": "^2.0.5",
                 "@types/markdown-it": "^12.0.1",
                 "@types/markdown-it-link-attributes": "^3.0.1",
@@ -2012,6 +2013,12 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
             "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+            "dev": true
+        },
+        "node_modules/@types/lodash": {
+            "version": "4.14.182",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+            "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
             "dev": true
         },
         "node_modules/@types/luxon": {
@@ -9125,6 +9132,12 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
             "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+            "dev": true
+        },
+        "@types/lodash": {
+            "version": "4.14.182",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+            "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
             "dev": true
         },
         "@types/luxon": {

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -45,6 +45,7 @@
         "@rollup/plugin-replace": "^3.0.1",
         "@rollup/plugin-typescript": "^6.1.0",
         "@tsconfig/svelte": "^1.0.10",
+        "@types/lodash": "^4.14.182",
         "@types/luxon": "^2.0.5",
         "@types/markdown-it": "^12.0.1",
         "@types/markdown-it-link-attributes": "^3.0.1",

--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -4,7 +4,7 @@
     import turfBbox from '@turf/bbox';
     import MapRender from './MapRender.svelte';
     import { BLANK } from './mapStyles';
-    import { colorShapes, LIGHT_GREY, DARK_GREY } from './utils';
+    import { colorShapes, createRenderTooltip, LIGHT_GREY, DARK_GREY } from './utils';
 
     export let data; // values, and the key to match
     export let options; // contains the shapes to display & match
@@ -21,7 +21,6 @@
     };
 
     let aspectRatio;
-    let renderTooltip;
     let bbox;
     let activeShapes;
     $: ({ shapes, colorsScale = defaultColorsScale, legend, aspectRatio, activeShapes } = options);
@@ -31,7 +30,6 @@
     let layer;
     let source;
     let dataBounds;
-
     /*
 shapes: {
     type: 'geojson',
@@ -43,27 +41,17 @@ shapes: {
     url: ''
 }
 */
+
     function computeSourceLayerAndBboxes(values, newShapes, newColorScale) {
-        if ((newShapes.type === 'geojson' && !newShapes.geoJson) || !values) {
-            // We don't have everything we need yet
+        if (newShapes.type === 'geojson' && !newShapes.geoJson) {
             return;
         }
 
         if (newShapes.type === 'geojson') {
-            const computeColors = colorShapes(newShapes.geoJson, values, newColorScale);
+            const colorValues = values || newShapes.geoJson.features.map(() => ({ y: 0 }));
+            const computeColors = colorShapes(newShapes.geoJson, colorValues, newColorScale);
             const coloredShapes = computeColors.geoJson;
             dataBounds = computeColors.bounds;
-
-            renderTooltip = (hoveredFeatureName) => {
-                let hoveredFeatureValue = '';
-                const matchedFeature = values.find((item) => String(item.x) === hoveredFeatureName);
-                if (matchedFeature) {
-                    hoveredFeatureValue = matchedFeature.y;
-                }
-                const format = options?.tooltip?.label;
-                if (format) return format(hoveredFeatureName);
-                return `${hoveredFeatureName} &mdash; ${hoveredFeatureValue}`;
-            };
 
             source = {
                 type: 'geojson',
@@ -87,22 +75,21 @@ shapes: {
     }
 
     $: computeSourceLayerAndBboxes(data.value, shapes, colorsScale);
+    $: renderTooltip = createRenderTooltip(data?.value, options);
 </script>
 
-<div>
-    <MapRender
-        {style}
-        {source}
-        {layer}
-        {aspectRatio}
-        {dataBounds}
-        {colorsScale}
-        {legend}
-        {renderTooltip}
-        {bbox}
-        {activeShapes}
-    />
-</div>
+<MapRender
+    {style}
+    {source}
+    {layer}
+    {aspectRatio}
+    {dataBounds}
+    {colorsScale}
+    {legend}
+    {renderTooltip}
+    {bbox}
+    {activeShapes}
+/>
 
 <style>
 </style>

--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -72,17 +72,6 @@ shapes: {
             const coloredShapes = computeColors.geoJson;
             dataBounds = computeColors.bounds;
 
-            renderTooltip = (hoveredFeatureName) => {
-                let hoveredFeatureValue = '';
-                const matchedFeature = values.find((item) => String(item.x) === hoveredFeatureName);
-                if (matchedFeature) {
-                    hoveredFeatureValue = matchedFeature.y;
-                }
-                const format = options?.tooltip?.label;
-                if (format) return format(hoveredFeatureName);
-                return `${hoveredFeatureName} &mdash; ${hoveredFeatureValue}`;
-            };
-
             source = {
                 type: 'geojson',
                 data: coloredShapes,
@@ -105,6 +94,22 @@ shapes: {
     }
 
     $: computeSourceLayerAndBboxes(data.value, shapes, colorsScale);
+    $: renderTooltip = (hoveredFeature) => {
+        const values = data.value || [];
+        let hoveredFeatureValue = '';
+        const hoveredFeatureName = hoveredFeature.properties.label || hoveredFeature.properties.key;
+        const matchedFeature = values.find(
+            (item) => String(item.x) === hoveredFeature.properties.key
+        );
+        if (matchedFeature) {
+            hoveredFeatureValue = matchedFeature.y;
+        }
+        const format = options?.tooltip?.label;
+        if (format) return format(hoveredFeatureName);
+        return hoveredFeatureValue
+            ? `${hoveredFeatureName} &mdash; ${hoveredFeatureValue}`
+            : hoveredFeatureName;
+    };
 </script>
 
 <div>

--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -46,7 +46,9 @@
     let layer;
     let source;
     let dataBounds;
+
     /*
+shapes: {
     type: 'geojson',
     geoJson: {}
 }

--- a/packages/visualizations/src/components/Map/utils.js
+++ b/packages/visualizations/src/components/Map/utils.js
@@ -10,7 +10,7 @@ export const colorShapes = (geoJson, values, colorsScale, emptyValueColor) => {
     // Key in the values is "x"
     // Key in the shapes is "key"
     // We add a color property in the JSON
-    const rawValues = values.map(v => v.y);
+    const rawValues = values.map((v) => v.y);
     const min = Math.min(...rawValues);
     const max = Math.max(...rawValues);
     let colorMin;
@@ -37,12 +37,12 @@ export const colorShapes = (geoJson, values, colorsScale, emptyValueColor) => {
     }
 
     const dataMapping = {};
-    values.forEach(v => {
+    values.forEach((v) => {
         dataMapping[v.x] = v.y;
     });
 
     // Iterate shapes, compute color from matching value
-    const coloredFeatures = geoJson.features.map(feature => {
+    const coloredFeatures = geoJson.features.map((feature) => {
         const shapeMapping = feature.properties.key;
         const value = dataMapping[shapeMapping]; // FIXME: beware of int/string differences in keys
         const color = value ? scale(value).hex() : emptyValueColor;
@@ -68,22 +68,18 @@ export const colorShapes = (geoJson, values, colorsScale, emptyValueColor) => {
 };
 
 export const mapKeyToColor = (values, colorScale) => {
-    const rawValues = values.map(v => v.y);
+    const rawValues = values.map((v) => v.y);
     const min = Math.min(...rawValues);
     const max = Math.max(...rawValues);
 
-    const colorMin = chroma(colorScale)
-        .darken(4)
-        .hex();
-    const colorMax = chroma(colorScale)
-        .brighten(4)
-        .hex();
+    const colorMin = chroma(colorScale).darken(4).hex();
+    const colorMax = chroma(colorScale).brighten(4).hex();
 
     const scale = chroma.scale([colorMin, colorMax]).domain([min, max]);
 
     const mapping = {};
 
-    values.forEach(v => {
+    values.forEach((v) => {
         mapping[v.x] = scale(v.y).hex();
     });
 
@@ -109,12 +105,12 @@ function computeBboxFromCoords(coordsPath, bbox) {
 // but we need the bounding box of the features themselves, so we need to build them again
 function mergeBboxFromFeaturesWithSameKey(features) {
     const mergedBboxes = {};
-    features.forEach(feature => {
+    features.forEach((feature) => {
         // FIXME: supports only shapes for now
         if (feature.geometry.type === 'Polygon') {
             // Compute extent first
             let bbox = VOID_BOUNDS;
-            feature.geometry.coordinates.forEach(coordsPath => {
+            feature.geometry.coordinates.forEach((coordsPath) => {
                 bbox = computeBboxFromCoords(coordsPath, bbox);
             });
             const id = feature.properties.key;
@@ -144,7 +140,7 @@ function mergeBboxFromFeaturesWithSameKey(features) {
 export const computeMaxZoomFromGeoJsonFeatures = (mapContainer, features) => {
     let maxZoom = 0; // maxZoom lowest value possible
     const filteredBboxes = mergeBboxFromFeaturesWithSameKey(features);
-    Object.values(filteredBboxes).forEach(value => {
+    Object.values(filteredBboxes).forEach((value) => {
         // Vtiles = 512 tilesize
         maxZoom = Math.max(
             geoViewport.viewport(
@@ -161,7 +157,7 @@ export const computeMaxZoomFromGeoJsonFeatures = (mapContainer, features) => {
     return maxZoom;
 };
 
-const getShapeCenter = feature => {
+const getShapeCenter = (feature) => {
     const featureBbox = turfBbox(feature.geometry);
     const centerLatitude = (featureBbox[1] + featureBbox[3]) / 2;
     const centerLongitude = (featureBbox[0] + featureBbox[2]) / 2;
@@ -169,8 +165,8 @@ const getShapeCenter = feature => {
 };
 
 export const getFixedTooltips = (shapeKeys, features, renderTooltip) => {
-    const popups = shapeKeys.map(shapeKey => {
-        const matchedFeature = features.find(feature => feature.properties.key === shapeKey);
+    const popups = shapeKeys.map((shapeKey) => {
+        const matchedFeature = features.find((feature) => feature.properties.key === shapeKey);
         if (matchedFeature) {
             const center = getShapeCenter(matchedFeature);
             const description = renderTooltip(matchedFeature);

--- a/packages/visualizations/src/components/Map/utils.js
+++ b/packages/visualizations/src/components/Map/utils.js
@@ -134,6 +134,23 @@ function mergeBboxFromFeaturesWithSameKey(features) {
     return mergedBboxes;
 }
 
+export const createRenderTooltip = (values, options) => {
+    if (!values) { return null }
+    
+    return (hoveredFeatureName) => {
+    
+        let hoveredFeatureValue = '';
+        const matchedFeature = values.find((item) => String(item.x) === hoveredFeatureName);
+        if (matchedFeature) {
+            hoveredFeatureValue = matchedFeature.y;
+        }
+        const format = options?.tooltip?.label;
+        if (format) return format(hoveredFeatureName);
+        return `${hoveredFeatureName} &mdash; ${hoveredFeatureValue}`;
+    }
+};
+
+
 // We're calculating the maximum zoom required to fit the smallest feature we're displaying, to prevent people from zooming "too far" by accident
 export const computeMaxZoomFromGeoJsonFeatures = (mapContainer, features) => {
     let maxZoom = 0; // maxZoom lowest value possible

--- a/packages/visualizations/src/components/Map/utils.js
+++ b/packages/visualizations/src/components/Map/utils.js
@@ -1,4 +1,6 @@
 import chroma from 'chroma-js';
+import turfBbox from '@turf/bbox';
+import maplibregl from 'maplibre-gl';
 import geoViewport from '@mapbox/geo-viewport';
 
 export const LIGHT_GREY = '#CBD2DB';
@@ -154,3 +156,29 @@ export const computeMaxZoomFromGeoJsonFeatures = (mapContainer, features) => {
     });
     return maxZoom;
 };
+
+const getShapeCenter = (feature) => {
+    const featureBbox = turfBbox(feature.geometry);
+    const centerLatitude = (featureBbox[1] + featureBbox[3]) / 2;
+    const centerLongitude = (featureBbox[0] + featureBbox[2]) / 2;
+    return [centerLongitude, centerLatitude];
+}
+
+export const getFixedTooltips = (shapeKeys, features, renderTooltip) => {
+    const popups = shapeKeys.map((shapeKey) => {
+        const matchedFeature = features.find((feature) => feature.properties.key === shapeKey);
+        if (matchedFeature) {
+            const center = getShapeCenter(matchedFeature);
+            const description = renderTooltip(matchedFeature);
+            const popup = new maplibregl.Popup({
+                closeOnClick: false,
+                closeButton: false,
+                className: 'tooltip-on-hover',
+            });
+            return { center, description, popup };
+        }
+        return null;
+    });
+
+    return popups;
+}

--- a/packages/visualizations/src/components/Map/utils.js
+++ b/packages/visualizations/src/components/Map/utils.js
@@ -10,7 +10,7 @@ export const colorShapes = (geoJson, values, colorsScale, emptyValueColor) => {
     // Key in the values is "x"
     // Key in the shapes is "key"
     // We add a color property in the JSON
-    const rawValues = values.map((v) => v.y);
+    const rawValues = values.map(v => v.y);
     const min = Math.min(...rawValues);
     const max = Math.max(...rawValues);
     let colorMin;
@@ -37,12 +37,12 @@ export const colorShapes = (geoJson, values, colorsScale, emptyValueColor) => {
     }
 
     const dataMapping = {};
-    values.forEach((v) => {
+    values.forEach(v => {
         dataMapping[v.x] = v.y;
     });
 
     // Iterate shapes, compute color from matching value
-    const coloredFeatures = geoJson.features.map((feature) => {
+    const coloredFeatures = geoJson.features.map(feature => {
         const shapeMapping = feature.properties.key;
         const value = dataMapping[shapeMapping]; // FIXME: beware of int/string differences in keys
         const color = value ? scale(value).hex() : emptyValueColor;
@@ -68,18 +68,22 @@ export const colorShapes = (geoJson, values, colorsScale, emptyValueColor) => {
 };
 
 export const mapKeyToColor = (values, colorScale) => {
-    const rawValues = values.map((v) => v.y);
+    const rawValues = values.map(v => v.y);
     const min = Math.min(...rawValues);
     const max = Math.max(...rawValues);
 
-    const colorMin = chroma(colorScale).darken(4).hex();
-    const colorMax = chroma(colorScale).brighten(4).hex();
+    const colorMin = chroma(colorScale)
+        .darken(4)
+        .hex();
+    const colorMax = chroma(colorScale)
+        .brighten(4)
+        .hex();
 
     const scale = chroma.scale([colorMin, colorMax]).domain([min, max]);
 
     const mapping = {};
 
-    values.forEach((v) => {
+    values.forEach(v => {
         mapping[v.x] = scale(v.y).hex();
     });
 
@@ -105,12 +109,12 @@ function computeBboxFromCoords(coordsPath, bbox) {
 // but we need the bounding box of the features themselves, so we need to build them again
 function mergeBboxFromFeaturesWithSameKey(features) {
     const mergedBboxes = {};
-    features.forEach((feature) => {
+    features.forEach(feature => {
         // FIXME: supports only shapes for now
         if (feature.geometry.type === 'Polygon') {
             // Compute extent first
             let bbox = VOID_BOUNDS;
-            feature.geometry.coordinates.forEach((coordsPath) => {
+            feature.geometry.coordinates.forEach(coordsPath => {
                 bbox = computeBboxFromCoords(coordsPath, bbox);
             });
             const id = feature.properties.key;
@@ -140,7 +144,7 @@ function mergeBboxFromFeaturesWithSameKey(features) {
 export const computeMaxZoomFromGeoJsonFeatures = (mapContainer, features) => {
     let maxZoom = 0; // maxZoom lowest value possible
     const filteredBboxes = mergeBboxFromFeaturesWithSameKey(features);
-    Object.values(filteredBboxes).forEach((value) => {
+    Object.values(filteredBboxes).forEach(value => {
         // Vtiles = 512 tilesize
         maxZoom = Math.max(
             geoViewport.viewport(
@@ -157,16 +161,16 @@ export const computeMaxZoomFromGeoJsonFeatures = (mapContainer, features) => {
     return maxZoom;
 };
 
-const getShapeCenter = (feature) => {
+const getShapeCenter = feature => {
     const featureBbox = turfBbox(feature.geometry);
     const centerLatitude = (featureBbox[1] + featureBbox[3]) / 2;
     const centerLongitude = (featureBbox[0] + featureBbox[2]) / 2;
     return [centerLongitude, centerLatitude];
-}
+};
 
 export const getFixedTooltips = (shapeKeys, features, renderTooltip) => {
-    const popups = shapeKeys.map((shapeKey) => {
-        const matchedFeature = features.find((feature) => feature.properties.key === shapeKey);
+    const popups = shapeKeys.map(shapeKey => {
+        const matchedFeature = features.find(feature => feature.properties.key === shapeKey);
         if (matchedFeature) {
             const center = getShapeCenter(matchedFeature);
             const description = renderTooltip(matchedFeature);
@@ -181,4 +185,4 @@ export const getFixedTooltips = (shapeKeys, features, renderTooltip) => {
     });
 
     return popups;
-}
+};

--- a/packages/visualizations/src/components/Map/utils.js
+++ b/packages/visualizations/src/components/Map/utils.js
@@ -134,23 +134,6 @@ function mergeBboxFromFeaturesWithSameKey(features) {
     return mergedBboxes;
 }
 
-export const createRenderTooltip = (values, options) => {
-    if (!values) { return null }
-    
-    return (hoveredFeatureName) => {
-    
-        let hoveredFeatureValue = '';
-        const matchedFeature = values.find((item) => String(item.x) === hoveredFeatureName);
-        if (matchedFeature) {
-            hoveredFeatureValue = matchedFeature.y;
-        }
-        const format = options?.tooltip?.label;
-        if (format) return format(hoveredFeatureName);
-        return `${hoveredFeatureName} &mdash; ${hoveredFeatureValue}`;
-    }
-};
-
-
 // We're calculating the maximum zoom required to fit the smallest feature we're displaying, to prevent people from zooming "too far" by accident
 export const computeMaxZoomFromGeoJsonFeatures = (mapContainer, features) => {
     let maxZoom = 0; // maxZoom lowest value possible


### PR DESCRIPTION
This PR aims at fixing tooltips value displaying.

Associated shortcut ticket [sc-34366/](https://app.shortcut.com/opendatasoft/story/34366/tooltip-doesn-t-display-the-value-in-some-cases)

## changes
The bug was due to the fact when the label field was the different than the key field, we tried to match the label with the key (probably tested only when name and key were the same).

Values is now an empty array by defaults to allow features with no properties at all.

`renderTooltip` now accepts a feature as a parameter and then use key and label where needed.

Added a cleanup reactive statement to clean popups when activeshapes empties (e.g. going from step 4 to 5 in the Studio).

Simplified center of shape calculation.

I also refactored tooltip rendering into smaller functions, with smaller responsabilities.

## Open discussion
The refactor seems a bit heavy in the diff, but it's mostly moving stuff. If you thing it makes it harder to spot the fix, I can rollback. The first idea was that it would be easier to add unit test on things like tooltip rendering. The second idea is to have as few functions as possible that modifies the comoponent state (top level `let` variables).

I tried to add some tests (in the React folder), but for now I have weird TS issues since the test only run in TSX (we would have to update our config to accept .jsx) but the maps aren't typed. I know it's bad practice, but since the bug is quite important, maybe we can do a separate ticket for tests?