### PR TITLE
Reset map zoom when interactivity is disabled

### DIFF
--- a/packages/visualizations/src/components/Map/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/MapRender.svelte
@@ -195,6 +195,10 @@ TODO:
             if (map.hasControl(nav)) {
                 map.removeControl(nav, 'top-left');
             }
+            // Reset map zoom
+            if (mapReady && bbox) {
+                fitMapToBbox(bbox);
+            };
         }
     }
 


### PR DESCRIPTION
The goal for this PR is to reset zoom on maps where interactivity is disabled, in case user has change default zoom and disable interactivity it avoids a frozen bad display of the map.