### PR TITLE
feat: pass more generic values to tooltip render

### DIFF
--- a/packages/visualizations/src/components/Map/Choropleth.svelte
+++ b/packages/visualizations/src/components/Map/Choropleth.svelte
@@ -96,21 +96,24 @@ shapes: {
     }
 
     $: computeSourceLayerAndBboxes(data.value, shapes, colorsScale);
+
+    const defaultFormat = ({ value, label, shapeKey }) =>
+        value ? `${label} &mdash; ${value}` : label;
+
     $: renderTooltip = (hoveredFeature) => {
         const values = data.value || [];
-        let hoveredFeatureValue = '';
-        const hoveredFeatureName = hoveredFeature.properties.label || hoveredFeature.properties.key;
         const matchedFeature = values.find(
             (item) => String(item.x) === hoveredFeature.properties.key
         );
-        if (matchedFeature) {
-            hoveredFeatureValue = matchedFeature.y;
-        }
+
+        const tooltipRawValues = {
+            value: matchedFeature?.y,
+            label: hoveredFeature.properties.label || hoveredFeature.properties.key,
+            shapeKey: hoveredFeature.properties.key,
+        };
         const format = options?.tooltip?.label;
-        if (format) return format(hoveredFeatureName);
-        return hoveredFeatureValue
-            ? `${hoveredFeatureName} &mdash; ${hoveredFeatureValue}`
-            : hoveredFeatureName;
+
+        return format ? format(tooltipRawValues) : defaultFormat(tooltipRawValues);
     };
 </script>
 


### PR DESCRIPTION
This PR aims at passing more values to toolitps in order allow for more rendering options, without having to rematch data/shapes manually.

## Open discussion
We pass the shapeKey, but maybe we could pass the dataKey (the "x") too? So that it's possible to do a fetch with more fields for exemples ?