### PR TITLE
API Client fixes after TSDX removal

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -13,10 +13,9 @@
         "JavaScript",
         "TypeScript"
     ],
-    "main": "dist/index.js",
-    "typings": "dist/index.d.ts",
-    "module": "dist/api-client.esm.js",
-    "unpkg": "dist/umd/opendatasoft.apiclient.umd.js",
+    "main": "dist/index.es.js",
+    "typings": "dist/src/index.d.ts",
+    "unpkg": "dist/umd/index.umd.js",
     "files": [
         "dist",
         "src",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -16,7 +16,7 @@
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
     "module": "dist/api-client.esm.js",
-    "unpkg": "umd/opendatasoft.apiclient.umd.js",
+    "unpkg": "dist/umd/opendatasoft.apiclient.umd.js",
     "files": [
         "dist",
         "src",

--- a/packages/api-client/rollup.config.js
+++ b/packages/api-client/rollup.config.js
@@ -75,7 +75,7 @@ const umd = defineConfig({
     input: 'src/index.ts',
     output: {
         dir: 'dist',
-        entryFileNames: '[name].umd.js',
+        entryFileNames: 'umd/[name].umd.js',
         format: 'umd',
         sourcemap: true,
         name: 'opendatasoft.visualizations',

--- a/packages/api-client/rollup.config.js
+++ b/packages/api-client/rollup.config.js
@@ -78,7 +78,7 @@ const umd = defineConfig({
         entryFileNames: 'umd/[name].umd.js',
         format: 'umd',
         sourcemap: true,
-        name: 'opendatasoft.visualizations',
+        name: 'opendatasoft.apiclient',
         plugins: [],
     },
     plugins: [


### PR DESCRIPTION
- changed paths in `package.json`
- moved UMD build into `umd` folder as before because [unpkg seems to expect it](https://unpkg.com/#workflow)
- changed the name of the global object from `opendatasoft.visualization` to `opendatasoft.apiclient` for ease of use