### PR TITLE
Use TurboSnap feature from Chromatic to reduce quota usage

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -33,3 +33,4 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_TOKEN }}
           workingDir: ./packages/visualizations-react
           storybookBuildDir: storybook-static
+          onlyChanged: true

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -39,7 +39,7 @@
         "size": "size-limit",
         "analyze": "size-limit --why",
         "storybook": "start-storybook -p 6006",
-        "build-storybook": "build-storybook"
+        "build-storybook": "build-storybook --webpack-stats-json"
     },
     "peerDependencies": {
         "react": ">=16"

--- a/packages/visualizations/src/components/KpiCard/KpiCard.svelte
+++ b/packages/visualizations/src/components/KpiCard/KpiCard.svelte
@@ -54,7 +54,7 @@
                             }}
                             aria-label={tooltipValue}
                             class="kpi-card__value-number">{displayValue}</span
-                        >{:else}<span class="kpi-card__value-number">{displayValue}</span
+                        >{:else}<span class="kpi-card__value-number">{displayValue} newtext</span
                         >{/if}{#if options.suffix}<span class="kpi-card__suffix"
                             >{options.suffix}</span
                         >{/if}

--- a/packages/visualizations/src/components/KpiCard/KpiCard.svelte
+++ b/packages/visualizations/src/components/KpiCard/KpiCard.svelte
@@ -54,7 +54,7 @@
                             }}
                             aria-label={tooltipValue}
                             class="kpi-card__value-number">{displayValue}</span
-                        >{:else}<span class="kpi-card__value-number">{displayValue} newtext</span
+                        >{:else}<span class="kpi-card__value-number">{displayValue}</span
                         >{/if}{#if options.suffix}<span class="kpi-card__suffix"
                             >{options.suffix}</span
                         >{/if}


### PR DESCRIPTION
## Summary

The goal for this PR is to reduce our Chromatic quota usage by leveraging TurboSnap, which should only compare snapshots for code that has changed.

### Changes

See https://www.chromatic.com/docs/turbosnap#enable

The PR just adds the relevant option to Chromatic.

## Review checklist

- [ ] Description is complete
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
