### PR TITLE
chore: added a command to rebuild lock files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "test": "lerna run test --parallel --no-bail",
         "bootstrap": "lerna bootstrap",
         "watch": "lerna run watch --parallel --stream",
-        "lint": "lerna run lint  --parallel --no-bail"
+        "lint": "lerna run lint  --parallel --no-bail",
+        "build-package-lock": "lerna run build-package-lock"
     },
     "devDependencies": {
         "lerna": "^5.5.0",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -28,6 +28,7 @@
     "scripts": {
         "watch": "rollup --config --watch",
         "build": "rollup --config",
+        "build-package-lock": "npm install --package-lock-only",
         "docs": "typedoc",
         "test": "jest",
         "lint": "run-p lint:*:check -c",

--- a/packages/visualizations-react/package-lock.json
+++ b/packages/visualizations-react/package-lock.json
@@ -4342,9 +4342,9 @@
             }
         },
         "node_modules/@opendatasoft/visualizations": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@opendatasoft/visualizations/-/visualizations-0.10.0.tgz",
-            "integrity": "sha512-hZsNmdgnoJeK4c7+jvv42sBA21q23PJEQfyGNUsVmm4AXCJkRVawB8xdr8Ut8jZMPg0lM95PgX91mLwf8IbIBw==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@opendatasoft/visualizations/-/visualizations-0.10.1.tgz",
+            "integrity": "sha512-KNqPmTqNrP1Ay8bXFth8dDKFYJSBN7yhjU391GNX8TE6MGqx9zmOV0yi0WDCZ8flQcysr+jTow23r4QnwOU89g==",
             "dependencies": {
                 "@mapbox/geo-viewport": "^0.5.0",
                 "@turf/bbox": "^6.5.0",
@@ -32861,9 +32861,9 @@
             }
         },
         "@opendatasoft/visualizations": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@opendatasoft/visualizations/-/visualizations-0.10.0.tgz",
-            "integrity": "sha512-hZsNmdgnoJeK4c7+jvv42sBA21q23PJEQfyGNUsVmm4AXCJkRVawB8xdr8Ut8jZMPg0lM95PgX91mLwf8IbIBw==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@opendatasoft/visualizations/-/visualizations-0.10.1.tgz",
+            "integrity": "sha512-KNqPmTqNrP1Ay8bXFth8dDKFYJSBN7yhjU391GNX8TE6MGqx9zmOV0yi0WDCZ8flQcysr+jTow23r4QnwOU89g==",
             "requires": {
                 "@mapbox/geo-viewport": "^0.5.0",
                 "@turf/bbox": "^6.5.0",

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -27,6 +27,7 @@
     "scripts": {
         "watch": "rollup --config --watch",
         "build": "rollup --config",
+        "build-package-lock": "npm install --package-lock-only",
         "docs": "typedoc",
         "test": "jest",
         "lint": "run-p lint:*:check -c",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -24,6 +24,7 @@
     "scripts": {
         "prepare": "rimraf dist && rollup --config",
         "build": "rollup --config",
+        "build-package-lock": "npm install --package-lock-only",
         "watch": "rollup --config --watch",
         "test": "echo \"No test specified\"",
         "lint": "run-p lint:*:check -c",


### PR DESCRIPTION
## Summary
This PR adds an npm script to rebuild package lock if they happen to not be in sync

With the new Lerna version, they are not rebuilt—which is great because they used to f* up the dff—and so can be out of sync with the package.json. Running the command will solve that.