### PR TITLE
Feat: Rename `tooltip.labelFormatter` callback into `tooltip.formatter` in Choropleths options

### DIFF
--- a/packages/visualizations-react/stories/Map/LegendLabelsRotation.stories.tsx
+++ b/packages/visualizations-react/stories/Map/LegendLabelsRotation.stories.tsx
@@ -16,13 +16,15 @@ const meta: ComponentMeta<typeof ChoroplethGeoJson> = {
 export default meta;
 
 const tooltip = {
-    labelFormatter: (feature: TooltipParams) =>
+    formatter: (feature: TooltipParams) =>
         `Hello I'm <div style="color: red">${
             feature.label
         }</div> and my value is <div style="color: red">${feature.value || ''}</div>`,
 };
 
-const Template: ComponentStory<typeof ChoroplethGeoJson> = (args: Props<DataFrame, ChoroplethGeoJsonOptions>) => (
+const Template: ComponentStory<typeof ChoroplethGeoJson> = (
+    args: Props<DataFrame, ChoroplethGeoJsonOptions>
+) => (
     <div
         style={{
             width: '180px',

--- a/packages/visualizations-react/stories/Map/StudioChoropleth.stories.tsx
+++ b/packages/visualizations-react/stories/Map/StudioChoropleth.stories.tsx
@@ -58,7 +58,7 @@ const StudioChoroplethArgs: Props<DataFrame, ChoroplethGeoJsonOptions> = {
         shapes,
         emptyValueColor: 'red',
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
         aspectRatio: 1,
         attribution: 'Testing attribution',
@@ -79,7 +79,7 @@ const StudioChoroplethMultiPolygonArgs: Props<DataFrame, ChoroplethGeoJsonOption
         shapes: multiPolygonShapes,
         emptyValueColor: 'red',
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
         aspectRatio: 1,
     },
@@ -99,7 +99,7 @@ const StudioChoroplethEmptyValueArgs: Props<DataFrame, ChoroplethGeoJsonOptions>
         shapes,
         emptyValueColor: 'red',
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
         aspectRatio: 1,
     },
@@ -120,7 +120,7 @@ const StudioChoroplethGradientArgs: Props<DataFrame, ChoroplethGeoJsonOptions> =
         shapes,
         emptyValueColor: 'red',
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
         colorScale: {
             type: ColorScaleTypes.Gradient,
@@ -151,7 +151,7 @@ const StudioChoroplethPaletteArgs: Props<DataFrame, ChoroplethGeoJsonOptions> = 
         shapes,
         emptyValueColor: 'red',
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
         colorScale: {
             type: ColorScaleTypes.Palette,
@@ -183,7 +183,7 @@ const StudioChoroplethCustomTooltipArgs: Props<DataFrame, ChoroplethGeoJsonOptio
             title: 'I Am Legend',
         },
         tooltip: {
-            labelFormatter: (feature: TooltipParams) =>
+            formatter: (feature: TooltipParams) =>
                 `Hello I'm <div style="color: red">${
                     feature.label
                 }</div> and my value is <div style="color: red">${feature.value || ''}</div>`,
@@ -211,7 +211,7 @@ const StudioChoroplethComplexTooltipArgs: Props<DataFrame, ChoroplethGeoJsonOpti
             title: 'I Am Legend',
         },
         tooltip: {
-            labelFormatter: (feature: TooltipParams) =>
+            formatter: (feature: TooltipParams) =>
                 `<div style="display: flex; flex-direction: column; justify-items: center; align-items: center">
                     <h2 style="border-bottom: 1px solid lightgrey">${feature.label}</h2>
                     <img src="${IMAGES.rocket}" style="margin-bottom: 15px"></img>
@@ -238,7 +238,7 @@ const StudioChoroplethLongLabelsArgs: Props<DataFrame, ChoroplethGeoJsonOptions>
         shapes,
         emptyValueColor: 'red',
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
         colorScale: {
             type: ColorScaleTypes.Palette,
@@ -267,7 +267,7 @@ const StudioChoroplethEmptyDataArgs: Props<DataFrame, ChoroplethGeoJsonOptions> 
             title: 'I Am Legend',
         },
         tooltip: {
-            labelFormatter: (feature: TooltipParams) =>
+            formatter: (feature: TooltipParams) =>
                 `Hello I'm <div style="color: red">${
                     feature.label
                 }</div> and my value is <div style="color: red">${feature.value || ''}</div>`,
@@ -301,7 +301,7 @@ const StudioChoroplethLegendLeftArgs: Props<DataFrame, ChoroplethGeoJsonOptions>
             position: LegendPositions.Left,
         },
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
     },
 };
@@ -332,7 +332,7 @@ const StudioChoroplethLegendRightArgs: Props<DataFrame, ChoroplethGeoJsonOptions
             position: LegendPositions.Right,
         },
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
     },
 };

--- a/packages/visualizations-react/stories/Map/StudioChoroplethVector.stories.tsx
+++ b/packages/visualizations-react/stories/Map/StudioChoroplethVector.stories.tsx
@@ -92,7 +92,7 @@ const StudioChoroplethVectorGradientArgs: Props<DataFrame, ChoroplethVectorTiles
         activeShapes: ['11', '93'],
         emptyValueColor: 'red',
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
     },
 };
@@ -117,7 +117,7 @@ const StudioChoroplethVectorPaletteArgs: Props<DataFrame, ChoroplethVectorTilesO
         emptyValueColor: 'red',
         bbox: [-17.529298, 38.79776, 23.889159, 52.836618],
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
     },
 };
@@ -142,7 +142,7 @@ const StudioChoroplethVectorFilterArgs: Props<DataFrame, ChoroplethVectorTilesOp
         aspectRatio: 1,
         bbox: [-5.637513, 45.500521, 1.382751, 49.219343],
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
             labelMatcher: {
                 type: ChoroplethTooltipMatcherTypes.KeyProperty,
                 key: 'reg_code',
@@ -175,7 +175,7 @@ const StudioChoroplethVectorCustomLabelArgs: Props<DataFrame, ChoroplethVectorTi
         aspectRatio: 1,
         bbox: [-5.637513, 45.500521, 1.382751, 49.219343],
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
             labelMatcher: {
                 type: ChoroplethTooltipMatcherTypes.KeyMap,
                 mapping: {
@@ -211,7 +211,7 @@ const StudioChoroplethVectorEmptyDataArgs: Props<DataFrame, ChoroplethVectorTile
         aspectRatio: 1,
         bbox: [-5.637513, 45.500521, 1.382751, 49.219343],
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
             labelMatcher: {
                 type: ChoroplethTooltipMatcherTypes.KeyMap,
                 mapping: {
@@ -250,7 +250,7 @@ const StudioChoroplethVectorLegendLeftArgs: Props<DataFrame, ChoroplethVectorTil
         aspectRatio: 1,
         bbox: [-5.637513, 45.500521, 1.382751, 49.219343],
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
         filter: {
             key: 'reg_code',
@@ -282,7 +282,7 @@ const StudioChoroplethVectorLegendRightArgs: Props<DataFrame, ChoroplethVectorTi
         aspectRatio: 1,
         bbox: [-5.637513, 45.500521, 1.382751, 49.219343],
         tooltip: {
-            labelFormatter: defaultLabelCallback,
+            formatter: defaultLabelCallback,
         },
         filter: {
             key: 'reg_code',
@@ -349,7 +349,7 @@ StudioChoroplethVectorLegendRight.args = StudioChoroplethVectorLegendRightArgs;
 //         aspectRatio: 1,
 //         bbox: [-17.529298, 38.79776, 23.889159, 52.836618],
 //         tooltip: {
-//             labelFormatter: defaultLabelCallback,
+//             formatter: defaultLabelCallback,
 //         },
 //     },
 // };

--- a/packages/visualizations-react/stories/Map/Tooltip.stories.tsx
+++ b/packages/visualizations-react/stories/Map/Tooltip.stories.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import type { ChoroplethGeoJsonOptions, DataFrame, TooltipParams } from '@opendatasoft/visualizations';
+import type {
+    ChoroplethGeoJsonOptions,
+    DataFrame,
+    TooltipParams,
+} from '@opendatasoft/visualizations';
 import { ChoroplethGeoJson, Props } from '../../src';
 import { IMAGES } from '../utils';
 import { shapes } from './shapes';
@@ -11,7 +15,9 @@ const meta: ComponentMeta<typeof ChoroplethGeoJson> = {
 };
 
 export default meta;
-const Template: ComponentStory<typeof ChoroplethGeoJson> = (args: Props<DataFrame, ChoroplethGeoJsonOptions>) => (
+const Template: ComponentStory<typeof ChoroplethGeoJson> = (
+    args: Props<DataFrame, ChoroplethGeoJsonOptions>
+) => (
     <div
         style={{
             width: '50%',
@@ -58,7 +64,8 @@ const CustomSimpleTooltipArgs: Props<DataFrame, ChoroplethGeoJsonOptions> = {
         aspectRatio: 1,
         activeShapes: ['Corsica'],
         tooltip: {
-            labelFormatter: (feature: TooltipParams) => `Hello I'm <div style="color: red">${
+            formatter: (feature: TooltipParams) =>
+                `Hello I'm <div style="color: red">${
                     feature.label
                 }</div> and my value is <div style="color: red">${feature.value || ''}</div>`,
         },
@@ -81,7 +88,9 @@ const CustomComplexTooltipArgs: Props<DataFrame, ChoroplethGeoJsonOptions> = {
         aspectRatio: 1,
         activeShapes: ['Île de France'],
         tooltip: {
-            labelFormatter: (feature: TooltipParams) => `<div style="display: flex; flex-direction: column; justify-items: center; align-items: center">
+            formatter: (
+                feature: TooltipParams
+            ) => `<div style="display: flex; flex-direction: column; justify-items: center; align-items: center">
                         <h2 style="border-bottom: 1px solid lightgrey">${feature.label}</h2>
                         <img src="${IMAGES.rocket}" style="margin-bottom: 15px"></img>
                         <div style="margin-bottom: 15px">Number of space rockets: ${

--- a/packages/visualizations/src/components/Map/types.ts
+++ b/packages/visualizations/src/components/Map/types.ts
@@ -62,7 +62,7 @@ export interface MapLegend {
  */
 export type TooltipParams = {
     /** Numeric value of the shape */
-    value?: string;
+    value?: number;
     /** Label of the shape */
     label: string;
     /** Value of the key used to match shapes and numeric data */

--- a/packages/visualizations/src/components/Map/types.ts
+++ b/packages/visualizations/src/components/Map/types.ts
@@ -18,7 +18,7 @@ export interface ChoroplethOptions {
     emptyValueColor?: Color;
     /** Configuration for the content of the tooltips that are displayed on hover/touch. */
     tooltip?: {
-        labelFormatter?: ChoroplethTooltipFormatter;
+        formatter?: ChoroplethTooltipFormatter;
         /** Custom configuration to define how to get a label for each shapes.
          *
          * By default, the label will be taken from a `label` property in the shapes if it exists, or fallback to the key used to map the data and shapes. */
@@ -32,8 +32,6 @@ export interface ChoroplethOptions {
     title?: string;
     /** Subtitle of the map */
     subtitle?: string;
-    /** Custom formatting function to display data value */
-    valueFormatter?: (value: number) => string;
 }
 
 export interface MapFilter {

--- a/packages/visualizations/src/components/Map/types.ts
+++ b/packages/visualizations/src/components/Map/types.ts
@@ -32,6 +32,8 @@ export interface ChoroplethOptions {
     title?: string;
     /** Subtitle of the map */
     subtitle?: string;
+    /** Custom formatting function to display data value */
+    valueFormatter?: (value: number) => string;
 }
 
 export interface MapFilter {
@@ -62,7 +64,7 @@ export interface MapLegend {
  */
 export type TooltipParams = {
     /** Numeric value of the shape */
-    value?: number;
+    value?: string;
     /** Label of the shape */
     label: string;
     /** Value of the key used to match shapes and numeric data */

--- a/packages/visualizations/src/components/Map/utils.ts
+++ b/packages/visualizations/src/components/Map/utils.ts
@@ -269,7 +269,7 @@ export const computeTooltip: ComputeTooltipFunction = (
     }
 
     const tooltipRawValues: TooltipParams = {
-        value: matchedFeature?.y.toString(),
+        value: matchedFeature?.y,
         label: tooltipLabel,
         key: hoveredFeature.properties?.[matchKey], // === matchedFeature.x
     };

--- a/packages/visualizations/src/components/Map/utils.ts
+++ b/packages/visualizations/src/components/Map/utils.ts
@@ -17,7 +17,7 @@ import type {
     ComputeTooltipFunction,
     ChoroplethLayer,
 } from './types';
-import { ChoroplethTooltipMatcherTypes } from './types';
+import { ChoroplethTooltipMatcherTypes, TooltipParams } from './types';
 
 export const LIGHT_GREY: Color = '#CBD2DB';
 export const DARK_GREY: Color = '#515457';
@@ -268,12 +268,15 @@ export const computeTooltip: ComputeTooltipFunction = (
         }
     }
 
-    const tooltipRawValues: {
-        value?: number;
-        label: string;
-        key: string;
-    } = {
-        value: matchedFeature?.y,
+    let value = '';
+    if (matchedFeature?.y) {
+        value = options?.valueFormatter
+            ? options?.valueFormatter(matchedFeature?.y)
+            : matchedFeature.y.toString();
+    }
+
+    const tooltipRawValues: TooltipParams = {
+        value,
         label: tooltipLabel,
         key: hoveredFeature.properties?.[matchKey], // === matchedFeature.x
     };

--- a/packages/visualizations/src/components/Map/utils.ts
+++ b/packages/visualizations/src/components/Map/utils.ts
@@ -268,19 +268,12 @@ export const computeTooltip: ComputeTooltipFunction = (
         }
     }
 
-    let value = '';
-    if (matchedFeature?.y) {
-        value = options?.valueFormatter
-            ? options?.valueFormatter(matchedFeature?.y)
-            : matchedFeature.y.toString();
-    }
-
     const tooltipRawValues: TooltipParams = {
-        value,
+        value: matchedFeature?.y.toString(),
         label: tooltipLabel,
         key: hoveredFeature.properties?.[matchKey], // === matchedFeature.x
     };
-    const format = options?.tooltip?.labelFormatter;
+    const format = options?.tooltip?.formatter;
 
     return format ? format(tooltipRawValues) : defaultTooltipFormat(tooltipRawValues);
 };


### PR DESCRIPTION
## Summary
The goal for this PR is to rename the ambiguous `tooltip.labelFormatter` callback into `tooltip.formatter` which in fact can format the label AND the value for Choropleths tooltip.

_(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-37317](https://app.shortcut.com/opendatasoft/story/37317)._

## Review checklist
- [x] Description is complete
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
