### PR TITLE
Poc-filtre

### DIFF
--- a/packages/visualizations-react/package-lock.json
+++ b/packages/visualizations-react/package-lock.json
@@ -17,6 +17,7 @@
                 "@babel/preset-env": "^7.19.0",
                 "@babel/preset-react": "^7.18.6",
                 "@babel/preset-typescript": "^7.18.6",
+                "@opendatasoft/api-client": "^0.5.0",
                 "@rollup/plugin-babel": "^5.3.0",
                 "@rollup/plugin-commonjs": "^19.0.0",
                 "@rollup/plugin-json": "^4.1.0",
@@ -4339,6 +4340,18 @@
             "license": "MIT",
             "dependencies": {
                 "@octokit/openapi-types": "^10.3.0"
+            }
+        },
+        "node_modules/@opendatasoft/api-client": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@opendatasoft/api-client/-/api-client-0.5.0.tgz",
+            "integrity": "sha512-mxkR10i8FfOPlsrGQsAERpWxPvvsHWFYnnYmsfAe/3EaZ+voPJ8igb/Ux7M/Vstrmv7u1UjF6/pgzeacgPcO5g==",
+            "dev": true,
+            "dependencies": {
+                "immutability-helper": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@opendatasoft/visualizations": {
@@ -15982,6 +15995,12 @@
             "engines": {
                 "node": ">= 4"
             }
+        },
+        "node_modules/immutability-helper": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.1.1.tgz",
+            "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ==",
+            "dev": true
         },
         "node_modules/import-cwd": {
             "version": "3.0.0",
@@ -32860,6 +32879,15 @@
                 "@octokit/openapi-types": "^10.3.0"
             }
         },
+        "@opendatasoft/api-client": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@opendatasoft/api-client/-/api-client-0.5.0.tgz",
+            "integrity": "sha512-mxkR10i8FfOPlsrGQsAERpWxPvvsHWFYnnYmsfAe/3EaZ+voPJ8igb/Ux7M/Vstrmv7u1UjF6/pgzeacgPcO5g==",
+            "dev": true,
+            "requires": {
+                "immutability-helper": "^3.1.1"
+            }
+        },
         "@opendatasoft/visualizations": {
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@opendatasoft/visualizations/-/visualizations-0.10.1.tgz",
@@ -41302,6 +41330,12 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
             "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "dev": true
+        },
+        "immutability-helper": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.1.1.tgz",
+            "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ==",
             "dev": true
         },
         "import-cwd": {

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -61,6 +61,7 @@
         "@babel/preset-env": "^7.19.0",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
+        "@opendatasoft/api-client": "^0.5.0",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^19.0.0",
         "@rollup/plugin-json": "^4.1.0",

--- a/packages/visualizations-react/src/components/Filter.tsx
+++ b/packages/visualizations-react/src/components/Filter.tsx
@@ -1,0 +1,8 @@
+import { Filter as _Filter } from '@opendatasoft/visualizations';
+import { FC } from 'react';
+import { Props } from './Props';
+import wrap from './ReactImpl';
+
+// Explicit name and type are needed for storybook
+const Filter: FC<Props<string, string>> = wrap(_Filter);
+export default Filter;

--- a/packages/visualizations-react/src/index.tsx
+++ b/packages/visualizations-react/src/index.tsx
@@ -5,3 +5,4 @@ export { default as KpiCard } from './components/KpiCard';
 export { default as ChoroplethGeoJson } from './components/ChoroplethGeoJson';
 export { default as ChoroplethVectorTiles } from './components/ChoroplethVectorTiles';
 export { default as ChoroplethSvg } from './components/ChoroplethSvg';
+export { default as Filter } from './components/Filter';

--- a/packages/visualizations-react/stories/Filter.stories.tsx
+++ b/packages/visualizations-react/stories/Filter.stories.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { Async, createFilteredData } from '@opendatasoft/visualizations'; 
+import { Filter, KpiCard } from '../src';
+import { defaultSource } from './utils';
+
+console.log('story', createFilteredData)
+
+const kpiOptions =  {
+    header: 'Header',
+    title: 'Title',
+    prefix: '$',
+    suffix: ' M',
+    description: 'Description',
+    footer: 'Footer',
+    source: defaultSource,
+    // Kpi Card
+};
+
+const FilterStory = () => {
+    const filteredData = createFilteredData();
+
+    return (
+        <>
+            <Filter data={filteredData} options="hello" />
+            <KpiCard data={filteredData} options={kpiOptions} />
+        </>
+    );
+};
+
+const meta: ComponentMeta<typeof FilterStory> = {
+    title: 'Filter',
+    component: Filter,
+    decorators: [
+        Story => (
+                <div
+                    style={{
+                    display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        height: '90vh',
+                    }}
+                >
+                    {Story()}
+                </div>
+        ),
+    ],
+};
+export default meta;
+
+const Template: ComponentStory<typeof FilterStory> = (args: any) => (
+    <FilterStory {...args} />
+);
+export const FilterTestStory = Template.bind({});
+

--- a/packages/visualizations-react/stories/Filter.stories.tsx
+++ b/packages/visualizations-react/stories/Filter.stories.tsx
@@ -49,20 +49,17 @@ const FilterStory = () => {
         .groupBy(odsField('region_min'));
     
 
-    /* This could really be a helper in the api-client package 
-    * That packages more and more.
-    */
     const filterField = (query, [field, value]) => query.where(
         filter => all(filter, `${odsField(field)}:${string(value)}`)
     );
 
+    /* This could really be a helper in the api-client package */
     const makeFilter = (baseQuery) => {
         const filterValues: { [field: string]: any} = {};
 
         const makeQuery = () => {
             const entries = Object.entries(filterValues);
             const filteredQuery = entries.reduce(filterField, baseQuery);
-            console.log(filteredQuery);
             return filteredQuery;
         };
 
@@ -72,16 +69,25 @@ const FilterStory = () => {
             const filteredData = await client.get(query.toString());
             return filteredData.results[0]?.y;
         };
+
+        const clear = async (field) => {
+            delete filterValues[field];
+            const query = makeQuery();
+            const filteredData = await client.get(query.toString());
+            return filteredData.results[0]?.y;
+        };
         
-        return filter;
+        return { filter, clear };
     };
 
-    const filter = makeFilter(exQuery);
-    const filteredData = createFilteredData(filter);
+    const { filter, clear } = makeFilter(exQuery);
+    const filteredData = createFilteredData({ filter, clear });
 
+    const clearAgeLabel = () => filteredData.clear('age_label');
     return (
         <>
             <Filter data={filteredData} options={filterOptions1} />
+            <button type="button" onClick={clearAgeLabel}>Clear Age</button>
             <Filter data={filteredData} options={filterOptions2} />
             <KpiCard data={filteredData} options={kpiOptions} />
         </>

--- a/packages/visualizations-react/stories/Filter.stories.tsx
+++ b/packages/visualizations-react/stories/Filter.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { Async, createFilteredData } from '@opendatasoft/visualizations'; 
+import { createFilteredData } from '@opendatasoft/visualizations';
+import { ApiClient, fromCatalog, field, string } from '@opendatasoft/api-client';
+
 import { Filter, KpiCard } from '../src';
 import { defaultSource } from './utils';
-
-console.log('story', createFilteredData)
 
 const kpiOptions =  {
     header: 'Header',
@@ -18,7 +18,22 @@ const kpiOptions =  {
 };
 
 const FilterStory = () => {
-    const filteredData = createFilteredData();
+    const client = new ApiClient({ domain: 'public' });
+
+    const query = fromCatalog()
+        .dataset('coronavirus-tranche-age-urgences-sosmedecins-dep-france')
+        .query()
+        .select(`sum(tot_pass_emgy) as y`)
+        .groupBy(field('region_min'));
+
+    const fetcher = async (value: string) => {
+        const filterQuery = query.where(`${field('region_min')}:${string(value)}`);
+        const filteredData = await client.get(filterQuery.toString());
+        console.log(filteredData);
+        return filteredData.results[0]?.y;
+    };
+
+    const filteredData = createFilteredData(fetcher);
 
     return (
         <>
@@ -53,4 +68,3 @@ const Template: ComponentStory<typeof FilterStory> = (args: any) => (
     <FilterStory {...args} />
 );
 export const FilterTestStory = Template.bind({});
-

--- a/packages/visualizations/src/components/Filter/Filter.svelte
+++ b/packages/visualizations/src/components/Filter/Filter.svelte
@@ -13,8 +13,6 @@
     {/each}
 </select>
 
-<p>{JSON.stringify(filterValue)}</p>
-
 <style>
     /* your styles go here */
 </style>

--- a/packages/visualizations/src/components/Filter/Filter.svelte
+++ b/packages/visualizations/src/components/Filter/Filter.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    export let data: any;
+    export let options;
+
+    const filters = ['Auvergne-Rhône-Alpes', 'Bourgogne-Franche-Comté'];
+
+    let filterValue: string;
+
+    $: data.filter(filterValue);
+</script>
+
+<select name="filter" id="filter" bind:value={filterValue}>
+    {#each filters as filter}
+        <option value={filter}>{filter}</option>
+    {/each}
+</select>
+
+<p>{filterValue}</p>
+
+<style>
+    /* your styles go here */
+</style>

--- a/packages/visualizations/src/components/Filter/Filter.svelte
+++ b/packages/visualizations/src/components/Filter/Filter.svelte
@@ -1,21 +1,19 @@
 <script lang="ts">
     export let data: any;
-    export let options;
+    export let options: Array<{ label: string; value: any }>;
 
-    const filters = ['Auvergne-Rhône-Alpes', 'Bourgogne-Franche-Comté'];
-
-    let filterValue: string;
+    let filterValue: { field: string; value: string };
 
     $: data.filter(filterValue);
 </script>
 
 <select name="filter" id="filter" bind:value={filterValue}>
-    {#each filters as filter}
-        <option value={filter}>{filter}</option>
+    {#each options as option}
+        <option value={option.value}>{option.label}</option>
     {/each}
 </select>
 
-<p>{filterValue}</p>
+<p>{JSON.stringify(filterValue)}</p>
 
 <style>
     /* your styles go here */

--- a/packages/visualizations/src/components/Filter/index.ts
+++ b/packages/visualizations/src/components/Filter/index.ts
@@ -1,0 +1,8 @@
+import FilterImpl from './Filter.svelte';
+import SvelteImpl from '../SvelteImpl';
+
+export default class Filter extends SvelteImpl<string, string> {
+    protected getSvelteComponentClass(): typeof FilterImpl {
+        return FilterImpl;
+    }
+}

--- a/packages/visualizations/src/components/KpiCard/KpiCard.svelte
+++ b/packages/visualizations/src/components/KpiCard/KpiCard.svelte
@@ -5,7 +5,7 @@
     import SourceLink from '../utils/SourceLink.svelte';
     import { defaultCompactNumberFormat, defaultNumberFormat } from '../utils/formatter';
 
-    export let data: Async<number>;
+    export let data: any;
     export let options: KpiCardOptions;
 
     let displayValue: string;
@@ -17,9 +17,9 @@
 
     $: formatCompact = options.formatCompact || defaultCompactNumberFormat;
 
-    $: if (data.value !== undefined) {
-        displayValue = formatCompact(data.value);
-        tooltipValue = format(data.value);
+    $: if ($data?.value !== undefined) {
+        displayValue = formatCompact($data?.value);
+        tooltipValue = format($data?.value);
     } else {
         displayValue = '';
         tooltipValue = '';
@@ -27,8 +27,8 @@
 </script>
 
 <div class="kpi-card">
-    {#if data.error}
-        Error : {JSON.stringify(data.error)}
+    {#if $data?.error}
+        Error : {JSON.stringify($data?.error)}
     {:else}
         {#if options.header}
             <div class="kpi-card__header">{options.header}</div>
@@ -46,7 +46,7 @@
                 If you want to have a space (45 Cars), the prefix or suffix itself has to contain the space -->
                 <div class="kpi-card__value">
                     {#if options.prefix}<span class="kpi-card__prefix">{options.prefix}</span
-                        >{/if}{#if data.loading}<span
+                        >{/if}{#if $data?.loading}<span
                             class="kpi-card__value-loading"
                         />{:else if tooltipValue !== displayValue}<span
                             use:tippy={{

--- a/packages/visualizations/src/index.ts
+++ b/packages/visualizations/src/index.ts
@@ -3,6 +3,9 @@ export { default as MarkdownText } from './components/MarkdownText';
 export { default as KpiCard } from './components/KpiCard';
 export { ChoroplethGeoJson, ChoroplethVectorTiles } from './components/Map/WebGl';
 export { default as ChoroplethSvg } from './components/Map/Svg';
+export { default as Filter } from './components/Filter';
+export { default as createFilteredData } from './primitives/filteredData';
+
 export * from './types';
 export * from './components/types';
 export * from './components/Chart/types';

--- a/packages/visualizations/src/primitives/filteredData.ts
+++ b/packages/visualizations/src/primitives/filteredData.ts
@@ -6,7 +6,7 @@ export default (fetcher: any) => {
 
     return {
         subscribe,
-        filter: async (value: string) => {
+        filter: async (value) => {
             update(data => ({ ...data, loading: true }));
             const filteredData = await fetcher(value);
             set({ loading: false, value: filteredData });

--- a/packages/visualizations/src/primitives/filteredData.ts
+++ b/packages/visualizations/src/primitives/filteredData.ts
@@ -1,24 +1,15 @@
 import { writable } from "svelte/store";
-import { ApiClient, fromCatalog, field } from '@opendatasoft/api-client';
 import type { DataFrame } from "../components/types";
 
-const client = new ApiClient({ domain: 'public' });
-const query = fromCatalog()
-    .dataset('coronavirus-tranche-age-urgences-sosmedecins-dep-france')
-    .query()
-    .select(`sum(tot_pass_emgy) as y`);
-
-export default () => {
+export default (fetcher: any) => {
     const { subscribe, update, set } = writable({});
 
     return {
         subscribe,
-        filter: async (value: string) => {            
-            const filterQuery = query.where(`'${value}'`);
+        filter: async (value: string) => {
             update(data => ({ ...data, loading: true }));
-            const filteredData = await client.get(filterQuery.toString());
-            console.log(filteredData)
-            set({ loading: false, value: filteredData.results[0]?.y });
+            const filteredData = await fetcher(value);
+            set({ loading: false, value: filteredData });
         },
     };
 };

--- a/packages/visualizations/src/primitives/filteredData.ts
+++ b/packages/visualizations/src/primitives/filteredData.ts
@@ -1,0 +1,24 @@
+import { writable } from "svelte/store";
+import { ApiClient, fromCatalog, field } from '@opendatasoft/api-client';
+import type { DataFrame } from "../components/types";
+
+const client = new ApiClient({ domain: 'public' });
+const query = fromCatalog()
+    .dataset('coronavirus-tranche-age-urgences-sosmedecins-dep-france')
+    .query()
+    .select(`sum(tot_pass_emgy) as y`);
+
+export default () => {
+    const { subscribe, update, set } = writable({});
+
+    return {
+        subscribe,
+        filter: async (value: string) => {            
+            const filterQuery = query.where(`'${value}'`);
+            update(data => ({ ...data, loading: true }));
+            const filteredData = await client.get(filterQuery.toString());
+            console.log(filteredData)
+            set({ loading: false, value: filteredData.results[0]?.y });
+        },
+    };
+};

--- a/packages/visualizations/src/primitives/filteredData.ts
+++ b/packages/visualizations/src/primitives/filteredData.ts
@@ -1,15 +1,20 @@
 import { writable } from "svelte/store";
 import type { DataFrame } from "../components/types";
 
-export default (fetcher: any) => {
+export default ({ filter,  clear }) => {
     const { subscribe, update, set } = writable({});
 
     return {
         subscribe,
         filter: async (value) => {
             update(data => ({ ...data, loading: true }));
-            const filteredData = await fetcher(value);
+            const filteredData = await filter(value);
             set({ loading: false, value: filteredData });
         },
+        clear: async (value) => {
+            update((data) => ({ ...data, loading: true }));
+            const filteredData = await clear(value);
+            set({ loading: false, value: filteredData });
+        }
     };
 };


### PR DESCRIPTION
So… here is my take on filters. It's very minimal and add hoc for now, but hopefully the idea is there.

## Basic Idea
The basic idea is to add a "primitive" to the SDK, which represents filterable data, that is reactive across all of our blocks and can be mutated by others, like filter here. (Other primitives could be colorscale, condition for exemple). It's a svelte store, so that it's reactive inside all of our components. 

As you can see, you can totally use a svelte store in react (because it's pure JS) as long as it's passed to our components. It allows us to pass "filtered data" instead of data.

Right now it only does the "loading true/false" part as a bonus, but we could add: 
* Storing initial value and reseting to default.
* Same data could be modified by multiple components, we could track them if need be.
* Read the value outside of the component. One can subscribe to a Svelte store anywhere, see [this hook](https://stackoverflow.com/a/64320752/7508148) for exemple.

Everything would always be reactive in all the components.

## Not implemented
It's not typed yet, but the idea would it's easy to ensure a correct data type.

Components accepting both store and plain value. As you can see, I hard coded the store in the KPI, but in the end we should accept both format I think. There many ways to do that, either by accepting two dinstinct props or converting depending on type (with assertion).

## Questions
Right now, this new store/observable etc. is not specific to the api-client, but there is an argument for to be. If so my guess is we could move quite a bit of the `useDataFrame` into it. Or prodive to versions or provide an ods speicifc fetcher… whatever, I think there is room reduce boilerplate code for someone who would like to add
