### PR TITLE
Poc/filters-module-archi-split

### DIFF
--- a/packages/api-client/src/odsql/filter.ts
+++ b/packages/api-client/src/odsql/filter.ts
@@ -1,0 +1,31 @@
+import { type Query, search, fieldSelect, all } from ".";
+
+type Operator = typeof search | typeof fieldSelect;
+type Clause = { operator: Operator, value?: any };
+
+const applyClause =
+    (query: Query, clause: Clause) => query.where(filter => all(filter, clause.operator(clause.value)));
+
+/* Class would work as well */
+export default (baseQuery: Query /* { apiClient, datasetId } ? */) => {
+    /* Maybe we can fetch the type of field to match the right kind of filter? 
+    * Check field names etc.
+    */
+
+    const clauses: Clause[] = [];
+
+    const addFilter = (operator: Operator) => {
+        const clause: Clause = { operator };
+
+        clauses.push(clause); // Object to preserve reference
+
+        const set = (value: string) => { clause.value = value; };
+        const clear = () => { delete clause.value; };
+
+        return { set, clear };
+    };
+
+    const getQuery = () => clauses.reduce<Query>(applyClause, baseQuery);
+
+    return { addFilter, getQuery };
+};

--- a/packages/api-client/src/odsql/index.ts
+++ b/packages/api-client/src/odsql/index.ts
@@ -185,13 +185,6 @@ export const date = ({ year, month, day }: { year: number; month?: number; day?:
  */
 export const dateFromIsoString = (dateStr: string) => `date'${dateStr}'`;
 
-/* Very random, could be any other ODSQL helper… */
-export const search = (text: string) => `search("${text}")`;
-export const fieldSelect = (
-    { column, value }
-    : { column: string, value: string }
-) => `${field(column)}:${string(value)}`;
-
 export const all = (...conditions: (string | undefined | null)[]) =>
     conditions
         .filter(Boolean)
@@ -209,6 +202,7 @@ export const list = (...values: (string | undefined | null)[]) => values.filter(
 export const not = (condition: string | undefined | null) =>
     condition ? `not (${condition})` : '';
 
+/* POC FILTRES */
 /* Very random, could be date, all fields, IN… */
 export const search = (text: string) => `search("${text}")`;
 export const fieldSelect = ({ column, value }: { column: string; value: string }) =>
@@ -219,24 +213,11 @@ type Operator = typeof search | typeof fieldSelect;
 export type Clause = { operator: Operator; value?: any };
 
 /* Maybe one function per odperator? Lik addSearchClause, addSelectClause etc. */
-export const addClause = (operator: Operator, clauses: Clause[]) => {
-    const clause: Clause = { operator };
-    
-    const set = (value: string) => {
-        clause.value = value;
-    };
-
-    const clear = () => {
-        delete clause.value;
-    };
-
-    return { set, clear, clauses: [...clauses, clause] };
-};
 
 const applyClause = (query: Query, clause: Clause) => query.where(
     (filter) => all(filter, clause.operator(clause.value))
 );
-export const makeQueryAdapter = (query: Query, clauses: Clause[]) => clauses.reduce<Query>(applyClause, query);
+export const makeQueryAdapter = (clauses: Clause[]) => (query: Query) => clauses.reduce<Query>(applyClause, query);
 
 /* OLD Version that kept an internal state.
 It can seem useful, but it hides the state, making it difficult to react.
@@ -253,7 +234,7 @@ export const composeClauses = () => {
 
     const addClause = (operator: Operator) => {
         const clause: Clause = { operator }; // value undefined at this point
-        clauses.push = clause;
+        clauses.push(clause);
 
         const set = (value: any) => {
             clause.value = value;

--- a/packages/api-client/src/odsql/index.ts
+++ b/packages/api-client/src/odsql/index.ts
@@ -185,6 +185,13 @@ export const date = ({ year, month, day }: { year: number; month?: number; day?:
  */
 export const dateFromIsoString = (dateStr: string) => `date'${dateStr}'`;
 
+/* Very random, could be any other ODSQL helper… */
+export const search = (text: string) => `search("${text}")`;
+export const fieldSelect = (
+    { column, value }
+    : { column: string, value: string }
+) => `${field(column)}:${string(value)}`;
+
 export const all = (...conditions: (string | undefined | null)[]) =>
     conditions
         .filter(Boolean)

--- a/packages/visualizations-react/src/filters/Props.ts
+++ b/packages/visualizations-react/src/filters/Props.ts
@@ -1,8 +1,7 @@
-import { FilterStore } from "@opendatasoft/visualizations";
 import { HTMLAttributes } from "react";
 
 export interface FilterProps<Options> extends HTMLAttributes<HTMLElement> {
-    filterStore: FilterStore;
+    // filterStore: FilterStore;
     options: Options;
     tag?: string;
 }

--- a/packages/visualizations-react/src/filters/ReactFilterImpl.tsx
+++ b/packages/visualizations-react/src/filters/ReactFilterImpl.tsx
@@ -1,4 +1,4 @@
-import { BaseFilter, FilterStore } from '@opendatasoft/visualizations';
+import { BaseFilter } from '@opendatasoft/visualizations';
 import React, { FC, ForwardedRef, forwardRef, useEffect, useRef } from 'react';
 import { useMergeRefs } from 'use-callback-ref';
 import { FilterProps } from './Props';
@@ -7,7 +7,7 @@ import { FilterProps } from './Props';
 
 // Represent one of our component class's constructor like Chart
 type ComponentConstructor<Options, ComponentClass extends BaseFilter<Options>> =
-    new (container: HTMLElement, filterStore: FilterStore, options: Options) => ComponentClass;
+    new (container: HTMLElement, options: Options) => ComponentClass;
 
 // The wrapper build a function component for the given component class
 export default function wrap<Options, ComponentClass extends BaseFilter<Options>>(
@@ -15,7 +15,7 @@ export default function wrap<Options, ComponentClass extends BaseFilter<Options>
 ): FC<FilterProps<Options>> {
     // We use forwardRef to forward the actual ref of the container
     return forwardRef((props: FilterProps<Options>, forwardedRef: ForwardedRef<HTMLElement>) => {
-        const { tag, filterStore, options, ...elementProps } = props;
+        const { tag, options, ...elementProps } = props;
 
         // This ref will hold our SDK component instance
         const componentRef = useRef<ComponentClass | null>(null);
@@ -23,11 +23,6 @@ export default function wrap<Options, ComponentClass extends BaseFilter<Options>
         const containerRef = useRef<HTMLElement | null>(null);
         // By merging container ref and forwarded ref parent component could also access the container ref !
         const ref = useMergeRefs([forwardedRef, containerRef]);
-
-        // Update data (put before creating the component to skip the initial render)
-        useEffect(() => {
-            componentRef.current?.updateFilterStore(filterStore);
-        }, [filterStore]);
 
         // Update options (put before creating the component to skip the initial render)
         useEffect(() => {
@@ -38,7 +33,7 @@ export default function wrap<Options, ComponentClass extends BaseFilter<Options>
         useEffect(() => {
             const container = containerRef.current;
             if (container) {
-                const component = new ComponentConstructor(container, filterStore, options);
+                const component = new ComponentConstructor(container, options);
                 componentRef.current = component;
                 return () => {
                     component.destroy();

--- a/packages/visualizations-react/src/filters/Text.tsx
+++ b/packages/visualizations-react/src/filters/Text.tsx
@@ -1,8 +1,8 @@
 import { Text as _Text } from '@opendatasoft/visualizations';
 import { FC } from 'react';
-import { FilterProps } from './Props';
-import wrap from './ReactFilterImpl';
+import { Props } from '../components/Props';
+import wrap from '../components/ReactImpl';
 
 // Explicit name and type are needed for storybook
-const TextFilter: FC<FilterProps<{}>> = wrap(_Text);
+const TextFilter: FC<Props<null, any>> = wrap(_Text);
 export default TextFilter;

--- a/packages/visualizations/src/filters/components/SvelteFilterImpl.ts
+++ b/packages/visualizations/src/filters/components/SvelteFilterImpl.ts
@@ -11,17 +11,17 @@ export default abstract class SvelteFilterImpl<Options> extends BaseFilter<Optio
         this.svelteComponent = new ComponentClass({
             target: this.container,
             props: {
-                filterStore: this.filterStore,
+                // filterStore: this.filterStore,
                 options: this.options,
             },
         });
     }
 
-    protected onFilterStoreUpdated() {
-        this.svelteComponent?.$$set?.({
-            filterStore: this.filterStore,
-        });
-    }
+    // protected onFilterStoreUpdated() {
+    //     this.svelteComponent?.$$set?.({
+    //         filterStore: this.filterStore,
+    //     });
+    // }
 
     protected onOptionsUpdated() {
         this.svelteComponent?.$$set?.({

--- a/packages/visualizations/src/filters/components/Text/Text.svelte
+++ b/packages/visualizations/src/filters/components/Text/Text.svelte
@@ -1,34 +1,29 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
-    import type FilterStore from "../../filterStore";
-
-    export let filterStore: FilterStore;
-    export let options: {};
-
-    let componentFilterStore: any;
-
-    onMount(() => {
-        componentFilterStore = filterStore.register();
-        console.log('onmount', componentFilterStore);
-    })
+    // export let filterStore: FilterStore;
+    export let options: any;
+    export let data = null;
+    // onMount(() => {
+    //     componentFilterStore = filterStore.register();
+    //     console.log('onmount', componentFilterStore);
+    // });
 
     let value: string;
+    $: ({ applyFilter } = options);
 
-    function applyFilter(newValue: string) {
-        console.log('Filter', newValue);
-        componentFilterStore.setCurrentFilter({
-            type: 'text',
-            value: newValue
-        });
-    }
+    // function applyFilter(newValue: string) {
+    //     console.log('Filter', newValue);
+    //     componentFilterStore.setCurrentFilter({
+    //         type: 'text',
+    //         value: newValue,
+    //     });
+    // }
 
-    $: componentFilterStore && applyFilter(value);
+    $: applyFilter(value);
 </script>
 
 <div>
-    <input type="text" bind:value={value}>
+    <input type="text" bind:value />
 </div>
 
 <style>
-
 </style>

--- a/packages/visualizations/src/filters/components/Text/index.ts
+++ b/packages/visualizations/src/filters/components/Text/index.ts
@@ -1,7 +1,7 @@
 import TextImpl from './Text.svelte';
-import SvelteFilterImpl from '../SvelteFilterImpl';
+import SvelteImpl from '../../../components/SvelteImpl';
 
-export default class Text extends SvelteFilterImpl<{}> {
+export default class Text extends SvelteImpl<null, any> {
     protected getSvelteComponentClass(): typeof TextImpl {
         return TextImpl;
     }

--- a/packages/visualizations/src/types.ts
+++ b/packages/visualizations/src/types.ts
@@ -1,5 +1,3 @@
-import type FilterStore from "./filters/filterStore";
-
 export interface Async<T> {
     value?: T;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -49,23 +47,23 @@ export abstract class BaseComponent<Data, Options> {
 export abstract class BaseFilter<Options> {
     readonly container: HTMLElement;
 
-    protected filterStore: FilterStore;
+    // protected filterStore: FilterStore;
 
     protected options: Options;
 
-    constructor(container: HTMLElement, filterStore: FilterStore, options: Options) {
+    constructor(container: HTMLElement, options: Options) {
         this.container = container;
-        this.filterStore = filterStore;
+        // this.filterStore = filterStore;
         this.options = options;
         this.onCreate();
     }
 
-    public updateFilterStore(newFilterStore: FilterStore): void {
-        const oldFilterStore = this.filterStore;
-        this.filterStore = newFilterStore;
-        // FIXME: Why old? (copied from BaseComponent)
-        this.onFilterStoreUpdated(oldFilterStore);
-    }
+    // public updateFilterStore(newFilterStore: FilterStore): void {
+    //     const oldFilterStore = this.filterStore;
+    //     this.filterStore = newFilterStore;
+    //     // FIXME: Why old? (copied from BaseComponent)
+    //     this.onFilterStoreUpdated(oldFilterStore);
+    // }
 
     public updateOptions(newOptions: Options): void {
         const oldOptions = this.options;
@@ -79,7 +77,7 @@ export abstract class BaseFilter<Options> {
 
     protected abstract onCreate(): void;
 
-    protected abstract onFilterStoreUpdated(oldData: FilterStore): void;
+    // protected abstract onFilterStoreUpdated(oldData: FilterStore): void;
 
     protected abstract onOptionsUpdated(oldOptions: Options): void;
 


### PR DESCRIPTION
Here is my fork of the filters POC. I simplified things a lot compared to my original though… but I think it's enough.

My final idea is that we should not hold any internal state, but always return the new state and then the app does what it wants with it. So that users can modify this state however they like in between renders.

However we can export types and functions that makes the building of a filter trivial.

## Operators and clauses
The main thing, which will hold most of the intelligence of the filter are the `Operator` (should will name them `Filter` ?), which are tightlx linked to `Clauses`. 
* `Clauses`are a "smart"way to represent the value of the filter that can be read and emited by a componentan 
* `Operator` transforms a clause into an actual `Query`

And then we have a util to transform all `Clauses` into an actual Query based on the Operators.

I removed all kind of state management from those functions, in favor of pure funtions : ` (value) => clause` and/or ` (oldClauses, value) => newClauses`, but never mutating anything.


## Components
For now, I still think the component should be very dumb and holds little to no state. They should however be made to accept callbacks made from `Operators` and return value in form of `Clause`, that will hold all the logic.

In this example the text filter still hold an inter `value` but I think we should make that a prop and then the callback could modify this prop—or not. 


