### PR TITLE
Fix viewbox resizer not on currentViewBox and max bounds not refreshing

### DIFF
--- a/packages/visualizations-react/stories/Map/StudioChoroplethVector.stories.tsx
+++ b/packages/visualizations-react/stories/Map/StudioChoroplethVector.stories.tsx
@@ -304,7 +304,7 @@ const StudioChoroplethNavigationMapButtonsArgs: Props<DataFrame, ChoroplethVecto
         tooltip: {
             formatter: defaultLabelCallback,
         },
-        viewBox: [-17.529298, 38.79776, 23.889159, 52.836618],
+        bbox: [-17.529298, 38.79776, 23.889159, 52.836618],
         navigationMaps: [...makeMiniMaps(15),],
     },
 };

--- a/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
@@ -37,7 +37,6 @@
     let aspectRatio: number | undefined;
     let renderTooltip: MapRenderTooltipFunction;
     let bbox: BBox | undefined;
-    let viewBox: BBox | undefined;
     let activeShapes: string[] | undefined;
     let interactive: boolean;
     let legend: MapLegend | undefined;
@@ -66,7 +65,6 @@
         interactive = defaultInteractive,
         emptyValueColor = DEFAULT_COLORS.Default,
         bbox = VOID_BOUNDS,
-        viewBox,
         filter,
         attribution,
         title,
@@ -138,7 +136,6 @@
     {legend}
     {renderTooltip}
     {bbox}
-    {viewBox}
     {activeShapes}
     {interactive}
     {filterExpression}

--- a/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
@@ -37,7 +37,6 @@
     export let layer: MapLayer;
     // bounding box to start from, and restrict to it
     export let bbox: BBox | undefined;
-    export let viewBox: BBox | undefined = bbox;
     // option to disable map interactions
     export let interactive: boolean;
     // options to display legend
@@ -67,10 +66,6 @@
     let legendVariant: LegendVariant;
     $: legendVariant = clientWidth <= 375 ? 'fluid' : 'fixed';
 
-    // Used to set max bounds on map to avoid unecessary scrolls
-    let isViewBoxEqualToMap: boolean;
-    $: isViewBoxEqualToMap = bbox === viewBox;
-
     // Used to store fixed tooltips displayed on render
     // FIXME: This may not be useful anymore, and is very tied to Choropleth right now
     let fixedPopupsList: ChoroplethFixedTooltipDescription[] = [];
@@ -83,7 +78,7 @@
     let nav: NavigationControl;
 
     let mapReady = false;
-    let currentViewBox = viewBox;
+    let currentBbox = bbox;
     // Used to add a listener to resize map on container changes, canceled on destroy
     let resizer: ResizeObserver;
 
@@ -98,30 +93,22 @@
     const sourceId = `shape-source-${mapId}`;
     const layerId = `shape-layer-${mapId}`;
 
-    const fitBox = (box: BBox | LngLatBoundsLike) => {
-        // Using padding, keep enough room for controls (zoom) to make sure they don't hide anything
-        map.fitBounds(box as LngLatBoundsLike, {
-            animate: false,
-            padding: 40,
-        });
-    };
-
-    const setViewBox = (box: BBox | undefined) => {
+    const setBbox = (box: BBox | undefined) => {
         if (!box) {
             // zoom-out to bounds defined in the initialization
             map.setZoom(map.getMinZoom());
             return;
         }
-        fitBox(box);
-    };
-
-    function setMaxBounds(bounds: BBox) {
         // Cancel any saved max bounds to properly fitBounds
         map.setMaxBounds(null);
-        fitBox(bounds);
-        // Reset min zoom and movement
+        // Using padding, keep enough room for controls (zoom) to make sure they don't hide anything
+        map.fitBounds(box as LngLatBoundsLike, {
+            animate: false,
+            padding: 40,
+        });
+        // Set new map max bounds after bbox changes
         map.setMaxBounds(map.getBounds());
-    }
+    };
 
     function initializeMap() {
         const defaultCenter: LngLatLike = [3.5, 46];
@@ -149,18 +136,11 @@
 
     function initializeResizer() {
         // Set a resizeObserver to resize map on container size changes
-        // TODO: Do we really want to reset to the initial bbox each time?
         resizer = new ResizeObserver(
             debounce(() => {
                 map.resize();
-                if (isViewBoxEqualToMap) {
-                    map.setMaxBounds(null);
-                }
-                if (mapReady && currentViewBox) {
-                    setViewBox(currentViewBox);
-                }
-                if (isViewBoxEqualToMap) {
-                    map.setMaxBounds(map.getBounds());
+                if (mapReady && currentBbox) {
+                    setBbox(currentBbox);
                 }
             }, 100)
         );
@@ -227,14 +207,14 @@
 
     let active: number | undefined;
 
-    const setViewBoxFromButton = (mapSVG: NavigationMap, i: number) => () => {
-        currentViewBox = mapSVG.bbox;
+    const setBboxFromButton = (mapSVG: NavigationMap, i: number) => () => {
+        currentBbox = mapSVG.bbox;
         active = i;
     };
 
-    const resetViewBoxFromButton = () => {
+    const resetBboxFromButton = () => {
         active = undefined;
-        currentViewBox = viewBox;
+        currentBbox = bbox;
     };
 
     function handleInteractivity(
@@ -285,10 +265,11 @@
             if (map.hasControl(nav)) {
                 map.removeControl(nav);
             }
-            // Reset map viewBox to reset zoom
-            if (mapReady && viewBox) {
-                setViewBox(viewBox);
+            // Reset map Bbox to reset zoom
+            if (mapReady && bbox) {
                 active = undefined;
+                currentBbox = bbox;
+                setBbox(currentBbox);
             }
         }
     }
@@ -335,11 +316,8 @@
         handleInteractivity(interactive, renderTooltip);
     }
     $: updateStyle(style);
-    $: if (mapReady && currentViewBox) {
-        setViewBox(currentViewBox);
-    }
-    $: if (mapReady && bbox) {
-        setMaxBounds(bbox);
+    $: if (mapReady && currentBbox) {
+        setBbox(currentBbox);
     }
     $: if (fixedPopupsList?.length > 0 && (activeShapes?.length === 0 || !activeShapes)) {
         fixedPopupsList.forEach((fixedPopup) => fixedPopup.popup.remove());
@@ -370,7 +348,7 @@
     {/if}
     <div class="main">
         {#if navigationMaps && active !== undefined}
-            <BackButton on:click={resetViewBoxFromButton} />
+            <BackButton on:click={resetBboxFromButton} />
         {/if}
         <div id="map" bind:this={container} />
     </div>
@@ -393,7 +371,7 @@
                     {colorScale}
                     active={active === i}
                     showTooltip={interactive}
-                    on:click={setViewBoxFromButton(map, i)}
+                    on:click={setBboxFromButton(map, i)}
                 />
             {/each}
         </div>

--- a/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
@@ -153,11 +153,15 @@
         resizer = new ResizeObserver(
             debounce(() => {
                 map.resize();
-                if (isViewBoxEqualToMap) {map.setMaxBounds(null);};
+                if (isViewBoxEqualToMap) {
+                    map.setMaxBounds(null);
+                }
                 if (mapReady && currentViewBox) {
                     setViewBox(currentViewBox);
                 }
-                if (isViewBoxEqualToMap) {map.setMaxBounds(map.getBounds());};
+                if (isViewBoxEqualToMap) {
+                    map.setMaxBounds(map.getBounds());
+                }
             }, 100)
         );
         resizer.observe(container);

--- a/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
@@ -67,6 +67,10 @@
     let legendVariant: LegendVariant;
     $: legendVariant = clientWidth <= 375 ? 'fluid' : 'fixed';
 
+    // Used to set max bounds on map to avoid unecessary scrolls
+    let isViewBoxEqualToMap: boolean;
+    $: isViewBoxEqualToMap = bbox === viewBox;
+
     // Used to store fixed tooltips displayed on render
     // FIXME: This may not be useful anymore, and is very tied to Choropleth right now
     let fixedPopupsList: ChoroplethFixedTooltipDescription[] = [];
@@ -149,12 +153,13 @@
         resizer = new ResizeObserver(
             debounce(() => {
                 map.resize();
-                if (mapReady && viewBox) {
-                    setViewBox(viewBox);
+                if (isViewBoxEqualToMap) {map.setMaxBounds(null);};
+                if (mapReady && currentViewBox) {
+                    setViewBox(currentViewBox);
                 }
+                if (isViewBoxEqualToMap) {map.setMaxBounds(map.getBounds());};
             }, 100)
         );
-
         resizer.observe(container);
         // Disconnect the resize onDestroy
         return () => resizer?.disconnect();

--- a/packages/visualizations/src/components/Map/types.ts
+++ b/packages/visualizations/src/components/Map/types.ts
@@ -27,7 +27,6 @@ export interface ChoroplethOptions {
     /** Maximum boundaries of the map, outside of which the user cannot zoom/move
      * Also set the position of the map when rendering.
      * If undefined, will default, in order to:
-     * - bbox if specified
      * - Fit the content if the source is GeoJSON
      * - The world
      */

--- a/packages/visualizations/src/components/Map/types.ts
+++ b/packages/visualizations/src/components/Map/types.ts
@@ -24,15 +24,14 @@ export interface ChoroplethOptions {
          * By default, the label will be taken from a `label` property in the shapes if it exists, or fallback to the key used to map the data and shapes. */
         labelMatcher?: ChoroplethTooltipMatchers;
     };
-    /** Maximum boundaries of the map, outside of which the user cannot zoom/move */
-    bbox?: BBox | undefined;
-    /** Position of the map when rendering.
+    /** Maximum boundaries of the map, outside of which the user cannot zoom/move
+     * Also set the position of the map when rendering.
      * If undefined, will default, in order to:
      * - bbox if specified
      * - Fit the content if the source is GeoJSON
      * - The world
      */
-    viewBox?: BBox | undefined;
+    bbox?: BBox | undefined;
     /** Attribution to display on the map */
     attribution?: string;
     /** Title of the map */


### PR DESCRIPTION
## Summary

The goal for this PR is to fix two recent regressions : 

1) The resizer fits the map to the viewBox instead of the currentViewBox what produces a weird behaviour. If you select a map through navigation buttons, on resize it would take you back to default viewBox. Just replacing viewBox by the currentViewBox fixes that.

2) We removed setting the map max bounds from the resizer and as it is based on `map.getBounds()` after doing a first `fitBox(bbox)`, it causes a bad behaviour on resize and aspect ratio changes and sometimes constraining the map too much making it impossible to see everything.
The fix is to always set max bounds depending on the bbox or the currentBbox on each change, that way the map will be always limited even if you navigate through navigation buttons. It removes the necessity to have co-existing bbox and viewBox which IMO makes all the code easier to understand.

Please share your opinion as I'm not sure of what is the best behaviour to have 😄 

## Review checklist

- [ ] Description is complete
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
