### PR TITLE
New options for the select filter

### DIFF
--- a/packages/visualizations-react/stories/Filters/Select.stories.tsx
+++ b/packages/visualizations-react/stories/Filters/Select.stories.tsx
@@ -9,20 +9,24 @@ const meta: ComponentMeta<typeof Select> = {
 
 export default meta;
 
-const options = {
-    fieldName: 'field',
-    availableValues: ['one', 'two', 'three'],
-};
-
-const Template: ComponentStory<typeof Select> = () => {
+const Template: ComponentStory<typeof Select> = (args) => {
     const [query, setQuery] = useState<string | null>('');
     
     return (
         <>
-            <Select options={options} handleFilter={(value:string|null) => setQuery(value)} />
+            <Select {...args} handleFilter={(value:string|null) => setQuery(value)} />
             { query }
         </>
     );
 };
 
 export const SelectStory = Template.bind({});
+
+SelectStory.args = {
+    options: {
+        fieldName: 'field',
+        availableValues: ['one', 'two', 'three'],
+        multiple: false,
+        placeholder: 'Select a value'
+    },
+};

--- a/packages/visualizations/src/filters/components/Select/MultiSelect.svelte
+++ b/packages/visualizations/src/filters/components/Select/MultiSelect.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+    import { exactMatch, one } from '@opendatasoft/api-client';
+    import { createEventDispatcher } from 'svelte';
+    import type { DispatchedFilterEvent, SelectOptions } from '../../types';
+
+    export let placeholder: SelectOptions['placeholder'] = null;
+    export let fieldName: SelectOptions['fieldName'];
+    export let availableValues: SelectOptions['availableValues'];
+
+    const dispatch = createEventDispatcher<DispatchedFilterEvent>();
+
+    let selected: string[] = [];
+
+    function applyFilter(newValue: string[]) {
+        dispatch('filter', {
+            value: one(...newValue.filter(Boolean).map((v) => exactMatch(fieldName, v))),
+        });
+    }
+
+    $: applyFilter(selected);
+</script>
+
+<select multiple bind:value={selected}>
+    <option value>{placeholder || 'Select a value'}</option>
+    {#each availableValues as availableValue}
+        <option value={availableValue}>{availableValue}</option>
+    {/each}
+</select>
+
+<style>
+    select {
+        background-color: var(--filter-select-background-color, #ffffff);
+        font-size: var(--filter-select-font-size, 14px);
+        color: var(--filter-select-text-color, #565656);
+
+        /* CSS hack to style the select */
+        border-radius: var(--filter-select-border-radius, 30px);
+        border-color: transparent;
+        border-right: var(--filter-select-padding, 13px) solid transparent;
+        box-shadow: var(--filter-select-border-color, #d0d0d0) 0px 0px 0px 1px;
+        padding: var(--filter-select-padding, 13px);
+        padding-right: 0px;
+    }
+</style>

--- a/packages/visualizations/src/filters/components/Select/Select.svelte
+++ b/packages/visualizations/src/filters/components/Select/Select.svelte
@@ -13,6 +13,4 @@
     $: component = multiple ? MultiSelect : SingleSelect;
 </script>
 
-<div class="filter-select">
-    <svelte:component this={component} {...rest} on:filter />
-</div>
+<svelte:component this={component} {...rest} on:filter />

--- a/packages/visualizations/src/filters/components/Select/Select.svelte
+++ b/packages/visualizations/src/filters/components/Select/Select.svelte
@@ -3,7 +3,7 @@
     This is a minimal implementation of a filter, based on a standard HTML component.
     It mostly exists for demo and documentation purposes, and may be removed at a later time.
     */
-    import { exactMatch } from '@opendatasoft/api-client';
+    import { exactMatch, one } from '@opendatasoft/api-client';
     import { createEventDispatcher } from 'svelte';
     import type { DispatchedFilterEvent, SelectOptions } from '../../types';
 
@@ -11,26 +11,41 @@
 
     const dispatch = createEventDispatcher<DispatchedFilterEvent>();
 
-    $: ({ fieldName, availableValues } = options);
+    $: ({ fieldName, availableValues, placeholder = null, multiple = false } = options);
 
     let selected = '';
 
-    function applyFilter(newValue: string) {
-        dispatch('filter', {
-            value: newValue ? exactMatch(fieldName, newValue) : null,
-        });
+    function applyFilter(newValue: string | string[]) {
+        if (typeof newValue === 'string')
+            dispatch('filter', {
+                value: newValue ? exactMatch(fieldName, newValue) : null,
+            });
+        else {
+            dispatch('filter', {
+                value: one(...newValue.filter(Boolean).map((v) => exactMatch(fieldName, v))),
+            });
+        }
     }
 
     $: applyFilter(selected);
 </script>
 
 <div class="filter-select">
-    <select bind:value={selected}>
-        <option value>Select a value</option>
-        {#each availableValues as availableValue}
-            <option value={availableValue}>{availableValue}</option>
-        {/each}
-    </select>
+    {#if multiple}
+        <select multiple bind:value={selected}>
+            <option value>{placeholder || 'Select a value'}</option>
+            {#each availableValues as availableValue}
+                <option value={availableValue}>{availableValue}</option>
+            {/each}
+        </select>
+    {:else}
+        <select bind:value={selected}>
+            <option value>{placeholder || 'Select a value'}</option>
+            {#each availableValues as availableValue}
+                <option value={availableValue}>{availableValue}</option>
+            {/each}
+        </select>
+    {/if}
 </div>
 
 <style>

--- a/packages/visualizations/src/filters/components/Select/Select.svelte
+++ b/packages/visualizations/src/filters/components/Select/Select.svelte
@@ -3,63 +3,16 @@
     This is a minimal implementation of a filter, based on a standard HTML component.
     It mostly exists for demo and documentation purposes, and may be removed at a later time.
     */
-    import { exactMatch, one } from '@opendatasoft/api-client';
-    import { createEventDispatcher } from 'svelte';
-    import type { DispatchedFilterEvent, SelectOptions } from '../../types';
+    import type { SelectOptions } from '../../types';
+    import SingleSelect from './SingleSelect.svelte';
+    import MultiSelect from './MultiSelect.svelte';
 
     export let options: SelectOptions;
 
-    const dispatch = createEventDispatcher<DispatchedFilterEvent>();
-
-    $: ({ fieldName, availableValues, placeholder = null, multiple = false } = options);
-
-    let selected = '';
-
-    function applyFilter(newValue: string | string[]) {
-        if (typeof newValue === 'string')
-            dispatch('filter', {
-                value: newValue ? exactMatch(fieldName, newValue) : null,
-            });
-        else {
-            dispatch('filter', {
-                value: one(...newValue.filter(Boolean).map((v) => exactMatch(fieldName, v))),
-            });
-        }
-    }
-
-    $: applyFilter(selected);
+    $: ({ multiple = false, ...rest } = options);
+    $: component = multiple ? MultiSelect : SingleSelect;
 </script>
 
 <div class="filter-select">
-    {#if multiple}
-        <select multiple bind:value={selected}>
-            <option value>{placeholder || 'Select a value'}</option>
-            {#each availableValues as availableValue}
-                <option value={availableValue}>{availableValue}</option>
-            {/each}
-        </select>
-    {:else}
-        <select bind:value={selected}>
-            <option value>{placeholder || 'Select a value'}</option>
-            {#each availableValues as availableValue}
-                <option value={availableValue}>{availableValue}</option>
-            {/each}
-        </select>
-    {/if}
+    <svelte:component this={component} {...rest} on:filter />
 </div>
-
-<style>
-    .filter-select select {
-        background-color: var(--filter-select-background-color, #ffffff);
-        font-size: var(--filter-select-font-size, 14px);
-        color: var(--filter-select-text-color, #565656);
-
-        /* CSS hack to style the select */
-        border-radius: var(--filter-select-border-radius, 30px);
-        border-color: transparent;
-        border-right: var(--filter-select-padding, 13px) solid transparent;
-        box-shadow: var(--filter-select-border-color, #d0d0d0) 0px 0px 0px 1px;
-        padding: var(--filter-select-padding, 13px);
-        padding-right: 0px;
-    }
-</style>

--- a/packages/visualizations/src/filters/components/Select/SingleSelect.svelte
+++ b/packages/visualizations/src/filters/components/Select/SingleSelect.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+    import { exactMatch } from '@opendatasoft/api-client';
+    import { createEventDispatcher } from 'svelte';
+    import type { DispatchedFilterEvent, SelectOptions } from '../../types';
+
+    export let placeholder: SelectOptions['placeholder'] = null;
+    export let fieldName: SelectOptions['fieldName'];
+    export let availableValues: SelectOptions['availableValues'];
+
+    const dispatch = createEventDispatcher<DispatchedFilterEvent>();
+
+    let selected = '';
+
+    function applyFilter(newValue: string) {
+        dispatch('filter', {
+            value: newValue ? exactMatch(fieldName, newValue) : null,
+        });
+    }
+
+    $: applyFilter(selected);
+</script>
+
+<select bind:value={selected}>
+    <option value>{placeholder || 'Select a value'}</option>
+    {#each availableValues as availableValue}
+        <option value={availableValue}>{availableValue}</option>
+    {/each}
+</select>
+
+<style>
+    select {
+        background-color: var(--filter-select-background-color, #ffffff);
+        font-size: var(--filter-select-font-size, 14px);
+        color: var(--filter-select-text-color, #565656);
+
+        /* CSS hack to style the select */
+        border-radius: var(--filter-select-border-radius, 30px);
+        border-color: transparent;
+        border-right: var(--filter-select-padding, 13px) solid transparent;
+        box-shadow: var(--filter-select-border-color, #d0d0d0) 0px 0px 0px 1px;
+        padding: var(--filter-select-padding, 13px);
+        padding-right: 0px;
+    }
+</style>

--- a/packages/visualizations/src/filters/types.ts
+++ b/packages/visualizations/src/filters/types.ts
@@ -8,4 +8,6 @@ export type DispatchedFilterEvent = {
 export type SelectOptions = {
     fieldName: string;
     availableValues: string[];
+    multiple?: boolean;
+    placeholder?: string;
 };

--- a/packages/visualizations/src/filters/types.ts
+++ b/packages/visualizations/src/filters/types.ts
@@ -9,5 +9,5 @@ export type SelectOptions = {
     fieldName: string;
     availableValues: string[];
     multiple?: boolean;
-    placeholder?: string;
+    placeholder?: string | null;
 };


### PR DESCRIPTION
## Summary

The goal for this PR is to add customization to the select filter with two new props: multiple and placeholder

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-37067](https://app.shortcut.com/opendatasoft/story/37067).

### Changes

New options for the select filter:
- placeholder: Label displayed as the first select option
![image](https://user-images.githubusercontent.com/117300300/214069005-ac091640-0a81-48a1-806d-8faed6884b66.png)
- multiple: Allow to select more than one option
![image](https://user-images.githubusercontent.com/117300300/214069206-52473acc-0fc0-4b3f-a64d-514b3c79bd40.png)


### Changelog

Add two options for the select filter (multiple & placeholder)

## Review checklist

- [x] Description is complete
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
