### PR TITLE
Chore/immutability

### DIFF
--- a/packages/visualizations/package-lock.json
+++ b/packages/visualizations/package-lock.json
@@ -18,6 +18,7 @@
                 "chartjs-plugin-stacked100": "^1.2.0",
                 "chroma-js": "^2.1.2",
                 "d3-geo": "^3.0.1",
+                "immutability-helper": "^3.1.1",
                 "lodash": "^4.17.21",
                 "luxon": "^2.0.2",
                 "maplibre-gl": "2.1.9",
@@ -1822,9 +1823,9 @@
             }
         },
         "node_modules/@opendatasoft/api-client": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@opendatasoft/api-client/-/api-client-0.5.2.tgz",
-            "integrity": "sha512-RVf0CmzMOuKjppkKM7Q7xYYv2ps0uq4SYwN3R1UZgOLqeo6jBMiRFZ3xdfxvZLZppo27GVcJVwWuw3IDLrp4NQ==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@opendatasoft/api-client/-/api-client-0.6.0.tgz",
+            "integrity": "sha512-oomgvMRJuh0xdjM61pXWC8ytRbItkhmvtWbEs7s7mhFx/tJVDoz1PeO0WPaQnmrC9n0wZ3FG2wZhWHUHK0WKzA==",
             "dependencies": {
                 "immutability-helper": "^3.1.1"
             },
@@ -9252,9 +9253,9 @@
             }
         },
         "@opendatasoft/api-client": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@opendatasoft/api-client/-/api-client-0.5.2.tgz",
-            "integrity": "sha512-RVf0CmzMOuKjppkKM7Q7xYYv2ps0uq4SYwN3R1UZgOLqeo6jBMiRFZ3xdfxvZLZppo27GVcJVwWuw3IDLrp4NQ==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@opendatasoft/api-client/-/api-client-0.6.0.tgz",
+            "integrity": "sha512-oomgvMRJuh0xdjM61pXWC8ytRbItkhmvtWbEs7s7mhFx/tJVDoz1PeO0WPaQnmrC9n0wZ3FG2wZhWHUHK0WKzA==",
             "requires": {
                 "immutability-helper": "^3.1.1"
             }
@@ -9714,7 +9715,8 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ajv": {
             "version": "6.12.6",
@@ -9991,12 +9993,14 @@
         "chartjs-adapter-luxon": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/chartjs-adapter-luxon/-/chartjs-adapter-luxon-1.1.0.tgz",
-            "integrity": "sha512-CS+xBWEyXYVLBZ3dSY/MwlSXhz8er4JjkApazY84ft/++oOLsmkt6TaXBCsUFudum7QdoYmpxiL/gSp20+emkw=="
+            "integrity": "sha512-CS+xBWEyXYVLBZ3dSY/MwlSXhz8er4JjkApazY84ft/++oOLsmkt6TaXBCsUFudum7QdoYmpxiL/gSp20+emkw==",
+            "requires": {}
         },
         "chartjs-plugin-datalabels": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.0.0.tgz",
-            "integrity": "sha512-WBsWihphzM0Y8fmQVm89+iy99mmgejmj5/jcsYqwxSioLRL/zqJ4Scv/eXq5ZqvG3TpojlGzZLeaOaSvDm7fwA=="
+            "integrity": "sha512-WBsWihphzM0Y8fmQVm89+iy99mmgejmj5/jcsYqwxSioLRL/zqJ4Scv/eXq5ZqvG3TpojlGzZLeaOaSvDm7fwA==",
+            "requires": {}
         },
         "chartjs-plugin-stacked100": {
             "version": "1.2.1",
@@ -10267,7 +10271,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
             "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "csso": {
             "version": "4.2.0",
@@ -10675,7 +10680,8 @@
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
             "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-import-resolver-node": {
             "version": "0.3.6",
@@ -10778,7 +10784,8 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/eslint-plugin-svelte3/-/eslint-plugin-svelte3-3.2.1.tgz",
             "integrity": "sha512-YoBR9mLoKCjGghJ/gvpnFZKaMEu/VRcuxpSRS8KuozuEo7CdBH7bmBHa6FmMm0i4kJnOyx+PVsaptz96K6H/4Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -11198,7 +11205,8 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
             "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ieee754": {
             "version": "1.2.1",
@@ -12203,25 +12211,29 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
             "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-discard-duplicates": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
             "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-discard-empty": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
             "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-discard-overridden": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
             "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-load-config": {
             "version": "3.1.0",
@@ -12318,7 +12330,8 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
             "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.0",
@@ -12353,7 +12366,8 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
             "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-normalize-display-values": {
             "version": "5.0.1",
@@ -12529,7 +12543,8 @@
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.4.0.tgz",
             "integrity": "sha512-JwJ9bOz4XHLQtiLnX4mTSSDUdhu12WH8sTwy/XTDCSyPlah6IcV7NWeYBZscPEcceu2YnW8Y9sJCP40Z2UH9GA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "progress": {
             "version": "2.0.3",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -98,6 +98,7 @@
         "chartjs-plugin-stacked100": "^1.2.0",
         "chroma-js": "^2.1.2",
         "d3-geo": "^3.0.1",
+        "immutability-helper": "^3.1.1",
         "lodash": "^4.17.21",
         "luxon": "^2.0.2",
         "maplibre-gl": "2.1.9",

--- a/packages/visualizations/rollup.config.js
+++ b/packages/visualizations/rollup.config.js
@@ -22,6 +22,7 @@ function basePlugins() {
             dev: !production,
             include: 'src/**/*.svelte',
             emitCss: true,
+            immutable: true,
             preprocess: autoPreprocess({
                 scss: {
                     includePaths: ['src'],

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -126,7 +126,6 @@
             </figcaption>
         {/if}
         <div class="chart-container">
-            {JSON.stringify(chartConfig.data.labels)}
             <canvas use:chartJs={chartConfig} role="img" aria-label={options.ariaLabel} />
         </div>
         {#if options.source}

--- a/packages/visualizations/src/components/Map/Svg/Map.svelte
+++ b/packages/visualizations/src/components/Map/Svg/Map.svelte
@@ -21,7 +21,7 @@
         return {};
     };
 
-    $: fittedProjection = projection.fitSize([height, width], featureCollection);
+    $: fittedProjection = { ...projection.fitSize([height, width], featureCollection) };
     $: makePath = geoPath(fittedProjection);
     $: paths =
         featureCollection.features.map((f: Feature) => ({

--- a/packages/visualizations/src/components/Map/WebGl/ChoroplethGeoJson.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/ChoroplethGeoJson.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable={true} />
-
 <script lang="ts">
     import turfBbox from '@turf/bbox';
     import type { FilterSpecification, SourceSpecification } from 'maplibre-gl';

--- a/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable={true} />
-
 <script lang="ts">
     import type { FilterSpecification, SourceSpecification } from 'maplibre-gl';
     import type { BBox } from 'geojson';


### PR DESCRIPTION
## Summary

The goal for this PR is to enforce immutability on all Svelte component at compiler level. Since that what we want, we might as well enforce it as default rather than execption

It is still possible to opt out with `<svelte:options immutable={false} />`
### Changes
Modified mainly the Chart component that using a big object with updates for storing states. I decided to use the same `immutability-helper` that we use in the API client. It's just a convenience over `Object.assing({}, …)`… but convenient nonetheless 😅 We could use Ramda or Lodash, I don't mind really.

For other components it was mainly a check and removing `<svelte:options immutable />` that is not necessary anymore.

## Open discussion
Arguably we would also want to remove patterns like:
```
let reactive;

// drop
function() { const stuff = reactive *2; …}

//rather
function(reactiveVar) { const stuff = reactiveVar * 2; … }
```
in favor of adding an extra parameter to the function and using `reactive` as an attribute when called. 

This would remove some unsafe case (if the data actually mutates, or in rare case function unsafe equality checks). This would also had the added benefit of hoisting all those functions outside of the component scope and avoid some rerenders.

I left it out though, since it's quite a big overhaul and I did not spot code like this that would mess with immutability (functions are rerceated every props change in what I see).

