### PR TITLE
fix: node version for chromatic action

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,6 +5,10 @@ on: push
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [">=16 <18"]
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
## Summary

The goal for this PR is to fix the chromatic Github action workflow that fails since last week 

See https://github.com/opendatasoft/ods-dataviz-sdk/actions/runs/4313418002

### Changes

Defines the version of the node on which the workflow should run.

- [x] Description is complete
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
