### PR TITLE
Choropleth: Use case-insensitive matching for shape filtering

### DIFF
--- a/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
@@ -40,7 +40,7 @@
     let legend: MapLegend | undefined;
     let attribution: string | undefined;
     let filter: MapFilter | undefined;
-    let filterExpression: (string | string[])[] | undefined;
+    let filterExpression: FilterSpecification | undefined;
     let title: string | undefined;
     let subtitle: string | undefined;
     let navigationMaps: NavigationMap[] | undefined;

--- a/packages/visualizations/src/components/Map/utils.ts
+++ b/packages/visualizations/src/components/Map/utils.ts
@@ -219,13 +219,17 @@ export const getFixedTooltips = (
     ) as ChoroplethFixedTooltipDescription[];
 };
 
-export const computeFilterExpression = (filterConfig: MapFilter) => {
-    /** Transform a filter object from the options into a Maplibre filter expression */
+/** Transform a filter object from the options into a Maplibre filter expression */
+export const computeFilterExpression = (filterConfig: MapFilter): FilterSpecification => {
     const { key, value } = filterConfig;
-    const filterMatchExpression: string[] = ['in', key];
+    // The matching is case-insensitive to make it easier with unique administrative codes
+    // that may have varying case but still represent the same entity.
+    const filterMatchExpression: FilterSpecification = ['in', ['downcase', ['get', key]]];
+    const matchingValues: string[] = [];
     (Array.isArray(value) ? value : [value]).forEach((filterValue) => {
-        filterMatchExpression.push(filterValue.toString());
+        matchingValues.push(filterValue.toString().toLowerCase());
     });
+    filterMatchExpression.push(['literal', matchingValues]);
     return filterMatchExpression;
 };
 


### PR DESCRIPTION
## Summary

The goal for this PR is to use case-insensitive matching in Choropleth's shape filtering.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-39521]

### Changes
There are some counties (UK) where the administrative boundaries from our reference data contains uppercase alphanum characters (`E08000003`), but due to various technical reasons, it ends up passed as `e08000003`, so the matching doesn't work, and we filter everything out including the one thing we didn't want.
Considering solving the issue on the other end (platform) isn't realistic without adding an additional API call, and that there is 0 chance in real life that a shape identifier will mean different things with a different case, it seems reasonable to transform the matching to be case insensitive.

Adding `["get", key]` in the expression also required passing an explicit `literal` expression for the values, since before it was tolerated to just list the values inline.

#### Breaking Changes
None in theory

## Review checklist

- [ ] Description is complete
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
