### PR TITLE
Upgrade Svelte to 3.57.0

### DIFF
--- a/packages/visualizations/package-lock.json
+++ b/packages/visualizations/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@mapbox/geo-viewport": "^0.5.0",
-                "@opendatasoft/api-client": "^0.6.1",
                 "@turf/bbox": "^6.5.0",
                 "chart.js": "^3.8.2",
                 "chartjs-adapter-luxon": "^1.1.0",
@@ -66,9 +65,9 @@
                 "rollup-plugin-svelte": "^6.1.0",
                 "rollup-plugin-terser": "^7.0.2",
                 "rollup-plugin-visualizer": "^4.2.0",
-                "svelte": "^3.43.2",
-                "svelte-check": "^2.2.7",
-                "svelte-preprocess": "^4.9.8",
+                "svelte": "^3.57.0",
+                "svelte-check": "^2.10.3",
+                "svelte-preprocess": "^4.10.7",
                 "tslib": "^2.0.3",
                 "typescript": "4.6"
             },
@@ -1820,17 +1819,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/@opendatasoft/api-client": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@opendatasoft/api-client/-/api-client-0.6.0.tgz",
-            "integrity": "sha512-oomgvMRJuh0xdjM61pXWC8ytRbItkhmvtWbEs7s7mhFx/tJVDoz1PeO0WPaQnmrC9n0wZ3FG2wZhWHUHK0WKzA==",
-            "dependencies": {
-                "immutability-helper": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@popperjs/core": {
@@ -7270,28 +7258,27 @@
             }
         },
         "node_modules/svelte": {
-            "version": "3.49.0",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.49.0.tgz",
-            "integrity": "sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==",
+            "version": "3.57.0",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.57.0.tgz",
+            "integrity": "sha512-WMXEvF+RtAaclw0t3bPDTUe19pplMlfyKDsixbHQYgCWi9+O9VN0kXU1OppzrB9gPAvz4NALuoca2LfW2bOjTQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/svelte-check": {
-            "version": "2.2.7",
-            "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.2.7.tgz",
-            "integrity": "sha512-lH8ArmwVC+D314cToZkXBBfj7NlpvgQGP7nXCAMnNHo6hTEcbKcf/cAZgzbnAOTftjIJrmLHp+EDW887VJFSOQ==",
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.10.3.tgz",
+            "integrity": "sha512-Nt1aWHTOKFReBpmJ1vPug0aGysqPwJh2seM1OvICfM2oeyaA62mOiy5EvkXhltGfhCcIQcq2LoE0l1CwcWPjlw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "chalk": "^4.0.0",
+                "@jridgewell/trace-mapping": "^0.3.9",
                 "chokidar": "^3.4.1",
                 "fast-glob": "^3.2.7",
                 "import-fresh": "^3.2.1",
-                "minimist": "^1.2.5",
+                "picocolors": "^1.0.0",
                 "sade": "^1.7.4",
-                "source-map": "^0.7.3",
                 "svelte-preprocess": "^4.0.0",
                 "typescript": "*"
             },
@@ -7302,89 +7289,10 @@
                 "svelte": "^3.24.0"
             }
         },
-        "node_modules/svelte-check/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/svelte-check/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/svelte-check/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/svelte-check/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/svelte-check/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/svelte-check/node_modules/source-map": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/svelte-check/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/svelte-preprocess": {
-            "version": "4.9.8",
-            "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.9.8.tgz",
-            "integrity": "sha512-EQS/oRZzMtYdAprppZxY3HcysKh11w54MgA63ybtL+TAZ4hVqYOnhw41JVJjWN9dhPnNjjLzvbZ2tMhTsla1Og==",
+            "version": "4.10.7",
+            "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
+            "integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -7402,12 +7310,12 @@
             "peerDependencies": {
                 "@babel/core": "^7.10.2",
                 "coffeescript": "^2.5.1",
-                "less": "^3.11.3",
+                "less": "^3.11.3 || ^4.0.0",
                 "postcss": "^7 || ^8",
-                "postcss-load-config": "^2.1.0 || ^3.0.0",
+                "postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0",
                 "pug": "^3.0.0",
                 "sass": "^1.26.8",
-                "stylus": "^0.54.7",
+                "stylus": "^0.55.0",
                 "sugarss": "^2.0.0",
                 "svelte": "^3.23.0",
                 "typescript": "^3.9.5 || ^4.0.0"
@@ -9247,14 +9155,6 @@
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
-            }
-        },
-        "@opendatasoft/api-client": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@opendatasoft/api-client/-/api-client-0.6.0.tgz",
-            "integrity": "sha512-oomgvMRJuh0xdjM61pXWC8ytRbItkhmvtWbEs7s7mhFx/tJVDoz1PeO0WPaQnmrC9n0wZ3FG2wZhWHUHK0WKzA==",
-            "requires": {
-                "immutability-helper": "^3.1.1"
             }
         },
         "@popperjs/core": {
@@ -13244,89 +13144,31 @@
             "dev": true
         },
         "svelte": {
-            "version": "3.49.0",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.49.0.tgz",
-            "integrity": "sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==",
+            "version": "3.57.0",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.57.0.tgz",
+            "integrity": "sha512-WMXEvF+RtAaclw0t3bPDTUe19pplMlfyKDsixbHQYgCWi9+O9VN0kXU1OppzrB9gPAvz4NALuoca2LfW2bOjTQ==",
             "dev": true
         },
         "svelte-check": {
-            "version": "2.2.7",
-            "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.2.7.tgz",
-            "integrity": "sha512-lH8ArmwVC+D314cToZkXBBfj7NlpvgQGP7nXCAMnNHo6hTEcbKcf/cAZgzbnAOTftjIJrmLHp+EDW887VJFSOQ==",
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.10.3.tgz",
+            "integrity": "sha512-Nt1aWHTOKFReBpmJ1vPug0aGysqPwJh2seM1OvICfM2oeyaA62mOiy5EvkXhltGfhCcIQcq2LoE0l1CwcWPjlw==",
             "dev": true,
             "requires": {
-                "chalk": "^4.0.0",
+                "@jridgewell/trace-mapping": "^0.3.9",
                 "chokidar": "^3.4.1",
                 "fast-glob": "^3.2.7",
                 "import-fresh": "^3.2.1",
-                "minimist": "^1.2.5",
+                "picocolors": "^1.0.0",
                 "sade": "^1.7.4",
-                "source-map": "^0.7.3",
                 "svelte-preprocess": "^4.0.0",
                 "typescript": "*"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.7.3",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
             }
         },
         "svelte-preprocess": {
-            "version": "4.9.8",
-            "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.9.8.tgz",
-            "integrity": "sha512-EQS/oRZzMtYdAprppZxY3HcysKh11w54MgA63ybtL+TAZ4hVqYOnhw41JVJjWN9dhPnNjjLzvbZ2tMhTsla1Og==",
+            "version": "4.10.7",
+            "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
+            "integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
             "dev": true,
             "requires": {
                 "@types/pug": "^2.0.4",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -82,9 +82,9 @@
         "rollup-plugin-svelte": "^6.1.0",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-visualizer": "^4.2.0",
-        "svelte": "^3.43.2",
-        "svelte-check": "^2.2.7",
-        "svelte-preprocess": "^4.9.8",
+        "svelte": "^3.57.0",
+        "svelte-check": "^2.10.3",
+        "svelte-preprocess": "^4.10.7",
         "tslib": "^2.0.3",
         "typescript": "4.6"
     },


### PR DESCRIPTION
## Summary

The goal for this PR is to upgrade Svelte and its direct dependencies to the latest version. The main reason behind this is to integrate the support of `aria-description`: https://github.com/sveltejs/svelte/blob/master/CHANGELOG.md#3465

### Changes

Just upgrades to Svelte and other svelte core packages. I didn't upgrade all the other packages like the linter, because we may want to also bump TS and other stuff at the same time.

#### Breaking Changes

_describe the changes that are not backward compatible_

### Changelog

_short sentence to serve as a public changelog:_

For a bug: "We fixed a bug in the Map component: Middle-Earth's vector tiles are now available."

For a new feature: "In the Map component: It's now possible to display the route of Frodo's journey from Hobbiton to Mount Doom."

## Open discussion

_describe implementation points that you would like to discuss if any_

_describe functional behaviour that you would like to discuss if any_

## To be tested

_points that may not be obviously related to the changes but are impacted_

_special cases that are not widely known_

## Review checklist

- [ ] Description is complete
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
