### PR TITLE
[CHORE][DOC] Edit and rename links to Explore APIv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A monorepo for the Opendatasoft's libraries:
 
-- [`@opendatasoft/api-client`](packages/api-client/): An API client for the [Opendatasoft's APIv2](https://help.opendatasoft.com/apis/ods-search-v2/#search-api-v2).
+- [`@opendatasoft/api-client`](packages/api-client/): An API client for the [Opendatasoft's Explore APIv2](https://help.opendatasoft.com/apis/ods-explore-v2/).
 - [`@opendatasoft/visualizations`](packages/visualizations/): Components to easily build dashboards and visualizations on top of an Opendatasoft platform.
 - [`@opendatasoft/visualizations-react`](packages/visualizations-react/): A convenient React wrapper for the visualizations components.
 

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -1,6 +1,6 @@
 # @opendatasoft/api-client ![CI status](https://github.com/opendatasoft/ods-dataviz-sdk/workflows/CI/badge.svg)
 
-This package implements a Typescript/Javascript client library for [Opendatasoft's Search APIv2](https://help.opendatasoft.com/apis/ods-search-v2/#search-api-v2).
+This package implements a Typescript/Javascript client library for [Opendatasoft's Explore APIv2](https://help.opendatasoft.com/apis/ods-explore-v2/).
 
 -   [Installation](#installation)
 -   [Get started](#get-started)
@@ -238,9 +238,8 @@ Here are some samples to get you started.
 
 ## Resources
 
--   [Opendatasoft's APIv2 documentation](https://help.opendatasoft.com/apis/ods-search-v2/#search-api-v2)
--   [API Client Reference](docs/modules.md)
--   [Data Network API Console](https://data.opendatasoft.com/api/v2/console)
+-   [Opendatasoft's Explore APIv2 documentation](https://help.opendatasoft.com/apis/ods-explore-v2/)
+-   [Data Network Explore APIv2 Console](https://data.opendatasoft.com/api/v2/console)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

The goal for this PR is to update some links related to the explore API

## Open discussion

I removed the link to [API Client Reference](docs/modules.md) in `packages/api-client/README.md`
Is it related to something that has been deleted? 

## Review checklist

- [x] Description is complete
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [x] Code is ready for a release on NPM
