### PR TITLE
POI maps : update data object and add ApiExport type

### DIFF
--- a/packages/api-client/src/client/types.ts
+++ b/packages/api-client/src/client/types.ts
@@ -71,4 +71,4 @@ export interface ApiQuery<T> {
 
 export interface ApiExport<T> {
     [key: string]: T;
-};
+}

--- a/packages/api-client/src/client/types.ts
+++ b/packages/api-client/src/client/types.ts
@@ -68,3 +68,7 @@ export interface ApiQuery<T> {
     total_count?: number;
     results: T[];
 }
+
+export interface ApiExport<T> {
+    [key: string]: T;
+};

--- a/packages/visualizations-react/stories/Poi/PoiGeoJson.stories.tsx
+++ b/packages/visualizations-react/stories/Poi/PoiGeoJson.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { PoiMapOptions, Async } from '@opendatasoft/visualizations';
+import { PoiMapOptions } from '@opendatasoft/visualizations';
 import { FeatureCollection } from 'geojson';
 import { shapes } from './data';
 import { PoiGeoJson, Props } from '../../src';
@@ -14,7 +14,9 @@ const meta: ComponentMeta<typeof PoiGeoJson> = {
 
 export default meta;
 
-const Template: ComponentStory<typeof PoiGeoJson> = (args: Props<FeatureCollection, PoiMapOptions>) => (
+const Template: ComponentStory<typeof PoiGeoJson> = (
+    args: Props<FeatureCollection, PoiMapOptions>
+) => (
     <div
         style={{
             width: '50%',
@@ -30,7 +32,7 @@ const Template: ComponentStory<typeof PoiGeoJson> = (args: Props<FeatureCollecti
 
 export const PoiMapNoLayersParams = Template.bind({});
 const PoiMapNoLayersParamsArgs: Props<FeatureCollection, PoiMapOptions> = {
-    data: shapes as Async<FeatureCollection>,
+    data: { value: shapes },
     options: {
         style: DEMO_BASEMAP,
     },
@@ -46,7 +48,7 @@ const layerParams = {
 export const PoiMapNonInteractive = Template.bind({});
 
 const PoiMapNonInteractiveArgs: Props<FeatureCollection, PoiMapOptions> = {
-    data: shapes as Async<FeatureCollection>,
+    data: { value: shapes },
     options: {
         layerParams,
         style: DEMO_BASEMAP,
@@ -58,7 +60,7 @@ PoiMapNonInteractive.args = PoiMapNonInteractiveArgs;
 export const PoiMapMatchExpression = Template.bind({});
 
 const PoiMapMatchExpressionArgs: Props<FeatureCollection, PoiMapOptions> = {
-    data: shapes as Async<FeatureCollection>,
+    data: { value: shapes },
     options: {
         layerParams,
         style: DEMO_BASEMAP,

--- a/packages/visualizations/src/components/MapPoi/PoiGeoJson.svelte
+++ b/packages/visualizations/src/components/MapPoi/PoiGeoJson.svelte
@@ -8,8 +8,8 @@
     import { DEFAULT_LAYERS_PARAMS } from './constants';
     import type { PoiMapOptions, PoiMapLayer, LayerParams } from './types';
 
-    export let data: FeatureCollection; // values, and the key to match
-    export let options: PoiMapOptions; // contains the shapes to display & match
+    export let data: { value: FeatureCollection }; // values and geo points to display
+    export let options: PoiMapOptions;
 
     let bbox: BBox | undefined;
 
@@ -50,13 +50,13 @@
             : [DEFAULT_LAYERS_PARAMS];
     }
 
-    $: if (data) {
-        layers = computeSourceLayers(data);
+    $: if (data.value) {
+        layers = computeSourceLayers(data.value);
         // We need to check that features are not empty before computing bbox through turf,
         // if they are empty (through filtering for example) we fallback
         // to bbox from options (or if bbox is undefined we keep VOID_BOUNDS from initialization)
-        if (data.features.length > 0) {
-            renderedBbox = bbox || turfBbox(data);
+        if (data.value.features.length > 0) {
+            renderedBbox = bbox || turfBbox(data.value);
         }
     }
 </script>

--- a/packages/visualizations/src/components/MapPoi/types.ts
+++ b/packages/visualizations/src/components/MapPoi/types.ts
@@ -33,3 +33,8 @@ export type LayerParams = {
 };
 
 export type PoiMapLayer = CircleLayer;
+
+export type GeoPoint = {
+    lat: number;
+    lon: number;
+};


### PR DESCRIPTION
## Summary

The goal for this PR is to update `data` object to be consistent with other visualisation components and add `ApiExport` type to handle new typescript needs.

## Review checklist

- [ ] Description is complete
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
