### PR TITLE
fix: display zero value as 0 instead of null

### DIFF
--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -111,7 +111,7 @@
                         const percentaged = options?.axis?.assemblage?.percentaged ? '% ' : '';
                         // If the value is a percentage, we need to format the raw value
                         const formattedRawValue =
-                            percentaged && raw && typeof raw === 'number' && `(${format(raw)})`;
+                            percentaged && raw !== undefined && typeof raw === 'number' && `(${format(raw)})`;
                         const suffix = percentaged + formattedRawValue;
 
                         if (seriesType && parsed) {


### PR DESCRIPTION
## Summary

The goal for this PR is to fix a bug where zero value were displayed as null in the bar chart tooltip

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-41137](https://app.shortcut.com/opendatasoft/story/41137).

### Changelog

We fixed a bug where value 0 was display as null in the tooltip of bar chart.
## Review checklist

- [x] Description is complete
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
