### PR TITLE
feat: add-cutout-option-for-doughnut-charts

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,14 @@
     "version": "independent",
     "command": {
         "version": {
-            "message": "chore(release): publish new versions"
+            "message": "chore(release): publish new versions",
+            "conventionalCommits": true,
+            "exact": true
+        },
+        "publish": {
+          "message": "chore(release): publish new versions",
+          "conventionalCommits": true,
+          "exact": true
         }
     },
     "useNx": true

--- a/packages/visualizations-react/stories/Chart/RadialCharts/RadialCharts.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/RadialCharts/RadialCharts.stories.tsx
@@ -1,0 +1,145 @@
+import type { ChartOptions, DataFrame } from '@opendatasoft/visualizations';
+import { ChartSeriesType } from '@opendatasoft/visualizations';
+import { Meta } from '@storybook/react';
+import type { Props } from '../../../src';
+import { compactNumberFormatter, defaultSource } from '../../utils';
+
+import ChartTemplate from '../ChartTemplate';
+
+const meta: Meta = {
+    title: 'Chart/RadialCharts',
+};
+const df = [
+    { x: 'Alpha', y: 100 },
+    { x: 'Beta', y: 50 },
+    { x: 'Gamma', y: 20 },
+    { x: 'Delta', y: 30 },
+];
+export default meta;
+
+export const PieChart = ChartTemplate.bind({});
+const basePieChartArgs: Props<DataFrame, ChartOptions> = {
+    data: {
+        loading: false,
+        value: df,
+    },
+    options: {
+        labelColumn: 'x',
+        title: {
+            text: 'Pie Chart',
+        },
+        series: [
+            {
+                type: ChartSeriesType.Pie,
+                valueColumn: 'y',
+                backgroundColor : ['#CB4335', '#1F618D', '#F1C40F', '#27AE60']
+            },
+        ],
+    },
+};
+PieChart.args = basePieChartArgs;
+
+export const PieDataLabelCustomLegendValues = ChartTemplate.bind({});
+const PieDataLabelCustomLegendValuesArgs: Props<DataFrame, ChartOptions> = {
+    data: {
+        loading: false,
+        value: df,
+    },
+    options: {
+        labelColumn: 'x',
+        source: defaultSource,
+        series: [
+            {
+                type: ChartSeriesType.Pie,
+                valueColumn: 'y',
+                backgroundColor: ['#CB4335', '#1F618D', '#F1C40F', '#27AE60'],
+                dataLabels: {
+                    display: true,
+                },
+            },
+        ],
+        padding: 32,
+        legend: {
+            display: false,
+            custom: true,
+            position: 'bottom',
+            labels: {
+                text(index: number) {
+                    const xData = df[index].x;
+                    const yData = compactNumberFormatter.format(df[index].y);
+                    return `${xData} - ${yData}`;
+                },
+            },
+        },
+        title: {
+            text: 'Pie chart with title and legend with values',
+        },
+    },
+};
+PieDataLabelCustomLegendValues.args = PieDataLabelCustomLegendValuesArgs;
+
+
+export const DoughnutChart = ChartTemplate.bind({});
+const DoughnutChartArgs: Props<DataFrame, ChartOptions> = {
+    ...basePieChartArgs,
+    options: {
+        labelColumn: 'x',
+        title: {
+            text: 'Doughnut Chart',
+        },
+        series: [
+            {
+                type: ChartSeriesType.Doughnut,
+                valueColumn: 'y',
+                cutout: "65%",
+                backgroundColor : ['#CB4335', '#1F618D', '#F1C40F', '#27AE60']
+            },
+        ],
+    },
+};
+DoughnutChart.args = DoughnutChartArgs;
+
+export const DoughnutDataLabelCustomLegendValues = ChartTemplate.bind({});
+const DoughnutDataLabelCustomLegendValuesArgs: Props<DataFrame, ChartOptions> = {
+    data: {
+        loading: false,
+        value: [
+            { x: 'Alpha', y: 100 },
+            { x: 'Beta', y: 50 },
+            { x: 'Gamma', y: 20 },
+            { x: 'Delta', y: 30 },
+        ],
+    },
+    options: {
+        labelColumn: 'x',
+        source: defaultSource,
+        series: [
+            {
+                type: ChartSeriesType.Doughnut,
+                cutout:"65%",
+                valueColumn: 'y',
+                backgroundColor: ['#CB4335', '#1F618D', '#F1C40F', '#27AE60'],
+                dataLabels: {
+                    display: true,
+                },
+            },
+        ],
+        padding: 32,
+        legend: {
+            display: false,
+            custom: true,
+            position: 'bottom',
+            labels: {
+                text(index: number) {
+                    const xData = df[index].x;
+                    const yData = compactNumberFormatter.format(df[index].y);
+                    return `${xData} - ${yData}`;
+                },
+            },
+        },
+        title: {
+            text: 'Doughnut chart with title and legend with values',
+        },
+    },
+};
+DoughnutDataLabelCustomLegendValues.args = DoughnutDataLabelCustomLegendValuesArgs;

--- a/packages/visualizations-react/stories/Chart/StudioLayouts/DoughnutChart.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/StudioLayouts/DoughnutChart.stories.tsx
@@ -6,7 +6,7 @@ import { compactNumberFormatter, defaultSource } from '../../utils';
 import ChartTemplate from '../ChartTemplate';
 
 const meta: Meta = {
-    title: 'Chart/StudioLayouts/PieChart',
+    title: 'Chart/StudioLayouts/DoughnutChart',
 };
 
 export default meta;
@@ -18,8 +18,8 @@ const df = [
     { x: 'Delta', y: 30 },
 ];
 
-export const PieTitleSectorsName = ChartTemplate.bind({});
-const PieTitleSectorsNameArgs: Props<DataFrame,ChartOptions> = {
+export const DoughnutTitleSectorsName = ChartTemplate.bind({});
+const DoughnutTitleSectorsNameArgs: Props<DataFrame,ChartOptions> = {
             data: {
                 loading: false,
                 value: df,
@@ -29,8 +29,9 @@ const PieTitleSectorsNameArgs: Props<DataFrame,ChartOptions> = {
                 source: defaultSource,
                 series: [
                     {
-                        type: ChartSeriesType.Pie,
+                        type: ChartSeriesType.Doughnut,
                         valueColumn: 'y',
+                        cutout:"65%",
                         backgroundColor: ['#CB4335', '#1F618D', '#F1C40F', '#27AE60'],
                         dataLabels: {
                             display: true,
@@ -39,14 +40,14 @@ const PieTitleSectorsNameArgs: Props<DataFrame,ChartOptions> = {
                     },
                 ],
                 title: {
-                    text: 'Pie chart with title and sectors name',
+                    text: 'Doughnut chart with title and sectors name',
                 },
             },
 };
-PieTitleSectorsName.args = PieTitleSectorsNameArgs;
+DoughnutTitleSectorsName.args = DoughnutTitleSectorsNameArgs;
 
-export const PieTitleSectorsNameValue = ChartTemplate.bind({});
-const PieTitleSectorsNameValueArgs: Props<DataFrame, ChartOptions> = {
+export const DoughnutTitleSectorsNameValue = ChartTemplate.bind({});
+const DoughnutTitleSectorsNameValueArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
         value: df,
@@ -56,7 +57,8 @@ const PieTitleSectorsNameValueArgs: Props<DataFrame, ChartOptions> = {
         source: defaultSource,
         series: [
             {
-                type: ChartSeriesType.Pie,
+                type: ChartSeriesType.Doughnut,
+                cutout:"65%",
                 valueColumn: 'y',
                 backgroundColor: ['#CB4335', '#1F618D', '#F1C40F', '#27AE60'],
                 dataLabels: {
@@ -70,14 +72,14 @@ const PieTitleSectorsNameValueArgs: Props<DataFrame, ChartOptions> = {
             },
         ],
         title: {
-            text: 'Pie chart with title and sectors name with values',
+            text: 'Doughnut chart with title and sectors name with values',
         },
     },
 };
-PieTitleSectorsNameValue.args = PieTitleSectorsNameValueArgs;
+DoughnutTitleSectorsNameValue.args = DoughnutTitleSectorsNameValueArgs;
 
-export const PieTitleLegend = ChartTemplate.bind({});
-const PieTitleLegendArgs: Props<DataFrame, ChartOptions> = {
+export const DoughnutTitleLegend = ChartTemplate.bind({});
+const DoughnutTitleLegendArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
         value: df,
@@ -87,8 +89,9 @@ const PieTitleLegendArgs: Props<DataFrame, ChartOptions> = {
         source: defaultSource,
         series: [
             {
-                type: ChartSeriesType.Pie,
+                type: ChartSeriesType.Doughnut,
                 valueColumn: 'y',
+                cutout:"65%",
                 backgroundColor: ['#CB4335', '#1F618D', '#F1C40F', '#27AE60'],
             },
         ],
@@ -97,14 +100,14 @@ const PieTitleLegendArgs: Props<DataFrame, ChartOptions> = {
             position: 'right',
         },
         title: {
-            text: 'Pie chart with title and legend',
+            text: 'Doughnut chart with title and legend',
         },
     },
 };
-PieTitleLegend.args = PieTitleLegendArgs;
+DoughnutTitleLegend.args = DoughnutTitleLegendArgs;
 
-export const PieTitleLegendValues = ChartTemplate.bind({});
-const PieTitleLegendValuesArgs: Props<DataFrame, ChartOptions> = {
+export const DoughnutTitleLegendValues = ChartTemplate.bind({});
+const DoughnutTitleLegendValuesArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
         value: [
@@ -119,8 +122,9 @@ const PieTitleLegendValuesArgs: Props<DataFrame, ChartOptions> = {
         source: defaultSource,
         series: [
             {
-                type: ChartSeriesType.Pie,
+                type: ChartSeriesType.Doughnut,
                 valueColumn: 'y',
+                cutout:"65%",
                 backgroundColor: ['#CB4335', '#1F618D', '#F1C40F', 'rgb(39,174,96)'],
             },
         ],
@@ -136,9 +140,9 @@ const PieTitleLegendValuesArgs: Props<DataFrame, ChartOptions> = {
             },
         },
         title: {
-            text: 'Pie chart with title and legend with values',
+            text: 'Doughnut chart with title and legend with values',
         },
     },
 };
-PieTitleLegendValues.args = PieTitleLegendValuesArgs;
+DoughnutTitleLegendValues.args = DoughnutTitleLegendValuesArgs;
 

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -146,6 +146,16 @@
                 enable: options?.axis?.assemblage?.percentaged,
             },
         };
+
+        /**
+         * We cannot use a type guard due to a bug in ChartJS
+         * https://github.com/chartjs/Chart.js/issues/10896#issuecomment-1660559770
+         */
+        const { type: seriesType } = options.series[0];
+        if (seriesType === ChartSeriesType.Doughnut) {
+            (chartOptions as Exclude<ChartConfiguration<'doughnut'>['options'], undefined>).cutout =
+                options.series[0].cutout;
+        }
         chartConfig = update(chartConfig, { options: { $set: chartOptions } });
     }
 

--- a/packages/visualizations/src/components/Chart/datasets.ts
+++ b/packages/visualizations/src/components/Chart/datasets.ts
@@ -90,6 +90,15 @@ export default function toDataset(df: DataFrame, s: ChartSeries): ChartDataset {
             borderWidth: defaultValue(s.borderWidth, 2),
         };
     }
+    if (s.type === 'doughnut') {
+        return {
+            type: 'doughnut',
+            label: defaultValue(s.label, ''),
+            data: df.map((entry) => entry[s.valueColumn]),
+            backgroundColor: multipleChartJsColors(s.backgroundColor),
+            datalabels: chartJsDataLabels(s.dataLabels),
+        };
+    }
 
     throw new Error('Unknown chart type');
 }

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -138,13 +138,14 @@ export interface DataLabelsConfiguration {
     padding?: number;
 }
 
-export type ChartSeries = Line | Bar | Pie | Radar;
+export type ChartSeries = Line | Bar | Pie | Radar | Doughnut;
 
 export enum ChartSeriesType {
     Line = 'line',
     Bar = 'bar',
     Pie = 'pie',
     Radar = 'radar',
+    Doughnut = 'doughnut',
 }
 
 export interface Line {
@@ -196,6 +197,15 @@ export interface Radar {
     pointRadius?: number;
     pointBackgroundColor?: Color | Color[];
     borderWidth?: number;
+}
+export interface Doughnut {
+    type: ChartSeriesType.Doughnut;
+    valueColumn: string;
+    label?: string;
+    cutout: string;
+    backgroundColor?: Color | Color[];
+    dataLabels?: DataLabelsConfiguration;
+    indexAxis?: 'x' | 'y';
 }
 
 export type FillMode = false | number | string | { value: number };


### PR DESCRIPTION
## Summary

The goal for this PR is to allow adding a cutout to Doughnut charts as a percentage string

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-42059](https://app.shortcut.com/opendatasoft/story/42059).

### Changes

Adding a case handling where we check if `option` has a `cutout` property. We cannot use a type guard to check if we use a Doughnut chart because of a bug in ChartJS : https://github.com/chartjs/Chart.js/issues/10896#issuecomment-1660559770*/

Edit: Now we check if `chartType`is `Doughnut` so we can look for the series option `cutout` to put it in the `chartOptions`


## Review checklist

- [x] Description is complete
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
