### PR TITLE
[FEATURE][SC-42061] Add scatter chart

### DIFF
--- a/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
@@ -776,7 +776,7 @@ function randomNormal(mean = 0, stdDev = 1) {
     return z0 * stdDev + mean;
   }
   
-function generateNormalDistribution(n, xMean = 0, xStdDev = 1, yMean = 0, yStdDev = 1) {
+function generateNormalDistribution(n: number, xMean = 0, xStdDev = 1, yMean = 0, yStdDev = 1) {
     const points = [];
     for (let i = 0; i < n; i++) {
       points.push({
@@ -834,11 +834,11 @@ const ScatterplotNormalDistribChartArgs: Props<DataFrame, ChartOptions> = {
 };
 ScatterplotNormalDistribChart.args = ScatterplotNormalDistribChartArgs;
 
-function randomExponential(lambda) {
+function randomExponential(lambda :number) {
     return -Math.log(1.0 - Math.random()) / lambda;
   }
   
-  function generateExponentialDistribution(n, lambda = 1, yRange = [0, 1]) {
+  function generateExponentialDistribution(n :number, lambda = 1, yRange = [0, 1]) {
     const points = [];
     for (let i = 0; i < n; i++) {
       points.push({

--- a/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
@@ -710,3 +710,187 @@ const ColumnChartStackedGroupsArgs: Props<DataFrame, ChartOptions> = {
     },
 };
 ColumnChartStackedGroups.args = ColumnChartStackedGroupsArgs;
+function generateUniformDistribution(n:number, xRange = [0, 1], yRange = [0, 1]) {
+    const points = [];
+    for (let i = 0; i < n; i++) {
+      points.push({
+        x: xRange[0] + Math.random() * (xRange[1] - xRange[0]),
+        y: yRange[0] + Math.random() * (yRange[1] - yRange[0])
+      });
+    }
+    return points;
+  }
+  
+
+export const ScatterplotChart = ChartTemplate.bind({});
+const ScatterPlotChartArgs: Props<DataFrame, ChartOptions> = {
+    data: {
+        loading: false,
+        value: generateUniformDistribution(1000, [0, 10], [0, 10]),
+    },
+    options: {
+        labelColumn: 'label',
+        series: [
+            {
+                type: ChartSeriesType.Scatter,
+                valueColumn:"x",
+                indexAxis:"y",
+                label:"Group 1",
+                pointRadius: 5,
+                hitRadius: 5,
+                pointHoverRadius: 4,
+                backgroundColor: 'rgba(255, 0, 0, .5)',
+                dataLabels:{
+                    display:false
+                }
+            },
+        ],
+        legend: {
+            display: true,
+        },
+        axis: {
+            x: {
+                display: true,
+            },
+            y: {
+                display: true,
+            },
+            assemblage: {
+                stacked: false,
+                percentaged: false,
+            },
+        },
+        title: {
+            text: 'test with gap',
+        },
+    },
+};
+ScatterplotChart.args = ScatterPlotChartArgs;
+
+function randomNormal(mean = 0, stdDev = 1) {
+    let u1 = 0;
+    let u2 = 0;
+    while (u1 === 0) u1 = Math.random();
+    while (u2 === 0) u2 = Math.random();
+    const z0 = Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2);
+    return z0 * stdDev + mean;
+  }
+  
+function generateNormalDistribution(n, xMean = 0, xStdDev = 1, yMean = 0, yStdDev = 1) {
+    const points = [];
+    for (let i = 0; i < n; i++) {
+      points.push({
+        x: randomNormal(xMean, xStdDev),
+        y: randomNormal(yMean, yStdDev)
+      });
+    }
+    return points;
+  }
+
+  
+export const ScatterplotNormalDistribChart = ChartTemplate.bind({});
+const ScatterplotNormalDistribChartArgs: Props<DataFrame, ChartOptions> = {
+    data: {
+        loading: false,
+        value: generateNormalDistribution(1000, 5, 2, 5, 2),
+    },
+    options: {
+        labelColumn: 'label',
+        series: [
+            {
+                type: ChartSeriesType.Scatter,
+                valueColumn:"x",
+                indexAxis:"y",
+                label:"Group 1",
+                pointRadius: 5,
+                hitRadius: 5,
+                pointHoverRadius: 4,
+                pointBorderColor: "#00000000",
+                backgroundColor: 'rgba(255, 0, 0, .5)',
+                dataLabels:{
+                    display:false
+                }
+            },
+        ],
+        legend: {
+            display: true,
+        },
+        axis: {
+            x: {
+                display: true,
+            },
+            y: {
+                display: true,
+            },
+            assemblage: {
+                stacked: false,
+                percentaged: false,
+            },
+        },
+        title: {
+            text: 'test with gap',
+        },
+    },
+};
+ScatterplotNormalDistribChart.args = ScatterplotNormalDistribChartArgs;
+
+function randomExponential(lambda) {
+    return -Math.log(1.0 - Math.random()) / lambda;
+  }
+  
+  function generateExponentialDistribution(n, lambda = 1, yRange = [0, 1]) {
+    const points = [];
+    for (let i = 0; i < n; i++) {
+      points.push({
+        x: randomExponential(lambda),
+        y: yRange[0] + Math.random() * (yRange[1] - yRange[0])
+      });
+    }
+    return points;
+  }
+  
+  export const ScatterplotExponentialDistribChart = ChartTemplate.bind({});
+const ScatterplotExponentialDistribChartArgs: Props<DataFrame, ChartOptions> = {
+    data: {
+        loading: false,
+        value: generateExponentialDistribution(1000, 10, [0, 10]),
+    },
+    options: {
+        labelColumn: 'label',
+        series: [
+            {
+                type: ChartSeriesType.Scatter,
+                valueColumn:"x",
+                indexAxis:"y",
+                label:"Group 1",
+                pointRadius: 5,
+                hitRadius: 5,
+                pointBorderColor: "#000000",
+                pointHoverRadius: 4,
+                backgroundColor: 'rgba(255, 0, 0, .5)',
+                dataLabels:{
+                    display:false
+                }
+            },
+        ],
+        legend: {
+            display: true,
+        },
+        axis: {
+            x: {
+                display: true,
+            },
+            y: {
+                display: true,
+            },
+            assemblage: {
+                stacked: false,
+                percentaged: false,
+            },
+        },
+        title: {
+            text: 'test with gap',
+        },
+    },
+};
+ScatterplotExponentialDistribChart.args = ScatterplotExponentialDistribChartArgs;

--- a/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
@@ -6,12 +6,12 @@ import { COLORS } from '../../utils';
 import ChartTemplate from '../ChartTemplate';
 
 const meta: Meta = {
+    component: ChartTemplate,
     title: 'Chart/AxisAssemblages',
 };
 
 export default meta;
 
-export const AreaChartStacked = ChartTemplate.bind({});
 const AreaChartStackedArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -63,9 +63,8 @@ const AreaChartStackedArgs: Props<DataFrame, ChartOptions> = {
         },
     },
 };
-AreaChartStacked.args = AreaChartStackedArgs;
+export const AreaChartStacked =  {args: AreaChartStackedArgs};
 
-export const AreaChartPercentage = ChartTemplate.bind({});
 const AreaChartPercentageArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -117,9 +116,8 @@ const AreaChartPercentageArgs: Props<DataFrame, ChartOptions> = {
         },
     },
 };
-AreaChartPercentage.args = AreaChartPercentageArgs;
+export const AreaChartPercentage = {args: AreaChartPercentageArgs};
 
-export const LineChartStacked = ChartTemplate.bind({});
 const LineChartStackedArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -173,9 +171,8 @@ const LineChartStackedArgs: Props<DataFrame, ChartOptions> = {
         },
     },
 };
-LineChartStacked.args = LineChartStackedArgs;
+export const LineChartStacked = {args: LineChartStackedArgs};
 
-export const LineChartPercentage = ChartTemplate.bind({});
 const LineChartPercentageArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -229,9 +226,8 @@ const LineChartPercentageArgs: Props<DataFrame, ChartOptions> = {
         },
     },
 };
-LineChartPercentage.args = LineChartPercentageArgs;
+export const LineChartPercentage = {args: LineChartPercentageArgs};
 
-export const BarChartStacked = ChartTemplate.bind({});
 const BarChartStackedArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -301,9 +297,8 @@ const BarChartStackedArgs: Props<DataFrame, ChartOptions> = {
         },
     },
 };
-BarChartStacked.args = BarChartStackedArgs;
+export const BarChartStacked = {args: BarChartStackedArgs};
 
-export const BarChartPercentage = ChartTemplate.bind({});
 const BarChartPercentageArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -373,9 +368,8 @@ const BarChartPercentageArgs: Props<DataFrame, ChartOptions> = {
         },
     },
 };
-BarChartPercentage.args = BarChartPercentageArgs;
+export const BarChartPercentage = {args: BarChartPercentageArgs};
 
-export const BarChartStackedGroups = ChartTemplate.bind({});
 const BarChartStackedGroupsArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -471,9 +465,8 @@ const BarChartStackedGroupsArgs: Props<DataFrame, ChartOptions> = {
         },
     },
 };
-BarChartStackedGroups.args = BarChartStackedGroupsArgs;
+export const BarChartStackedGroups = {args: BarChartStackedGroupsArgs};
 
-export const ColumnChartStacked = ChartTemplate.bind({});
 const ColumnChartStackedArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -542,9 +535,8 @@ const ColumnChartStackedArgs: Props<DataFrame, ChartOptions> = {
         },
     },
 };
-ColumnChartStacked.args = ColumnChartStackedArgs;
+export const ColumnChartStacked = {args: ColumnChartStackedArgs};
 
-export const ColumnChartPercentage = ChartTemplate.bind({});
 const ColumnChartPercentageArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -613,10 +605,8 @@ const ColumnChartPercentageArgs: Props<DataFrame, ChartOptions> = {
         },
     },
 };
-ColumnChartPercentage.args = ColumnChartPercentageArgs;
+export const ColumnChartPercentage = {args: ColumnChartPercentageArgs};
 
-
-export const ColumnChartStackedGroups = ChartTemplate.bind({});
 const ColumnChartStackedGroupsArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -709,63 +699,53 @@ const ColumnChartStackedGroupsArgs: Props<DataFrame, ChartOptions> = {
         },
     },
 };
-ColumnChartStackedGroups.args = ColumnChartStackedGroupsArgs;
-function generateUniformDistribution(n:number, xRange = [0, 1], yRange = [0, 1]) {
-    const points = [];
-    for (let i = 0; i < n; i++) {
-      points.push({
-        x: xRange[0] + Math.random() * (xRange[1] - xRange[0]),
-        y: yRange[0] + Math.random() * (yRange[1] - yRange[0])
-      });
-    }
-    return points;
-  }
-  
+export const ColumnChartStackedGroups = {args: ColumnChartStackedGroupsArgs};
 
-export const ScatterplotChart = ChartTemplate.bind({});
 const ScatterPlotChartArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
-        value: generateUniformDistribution(1000, [0, 10], [0, 10]),
+        value: [
+            {label: 'id-0', x: -10, y: 20}, 
+            {label: 'id-1', x: 20, y: -10}, 
+            {label: 'id-2', x: 5, y: 2},
+            {label: 'id-3', x: 7, y: 3}
+        ],
     },
     options: {
         labelColumn: 'label',
         series: [
             {
                 type: ChartSeriesType.Scatter,
+                label: "Serie 1",
                 valueColumn:"x",
                 indexAxis:"y",
-                label:"Group 1",
-                pointRadius: 5,
-                hitRadius: 5,
-                pointHoverRadius: 4,
-                backgroundColor: 'rgba(255, 0, 0, .5)',
-                dataLabels:{
-                    display:false
-                }
+                backgroundColor: COLORS.blue,
             },
         ],
-        legend: {
-            display: true,
-        },
         axis: {
             x: {
                 display: true,
+                type: 'linear',
+                title: {
+                    display: true,
+                    text: "Horizontal axis"
+                },
             },
             y: {
                 display: true,
-            },
-            assemblage: {
-                stacked: false,
-                percentaged: false,
+                title: {
+                    display: true,
+                    text: "Vertical axis"
+                },
+                type: 'linear',
             },
         },
         title: {
-            text: 'test with gap',
+            text: 'Scatterplot Chart',
         },
     },
 };
-ScatterplotChart.args = ScatterPlotChartArgs;
+export const ScatterplotChart = {args: ScatterPlotChartArgs};
 
 function randomNormal(mean = 0, stdDev = 1) {
     let u1 = 0;
@@ -775,122 +755,59 @@ function randomNormal(mean = 0, stdDev = 1) {
     const z0 = Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2);
     return z0 * stdDev + mean;
   }
-  
+
 function generateNormalDistribution(n: number, xMean = 0, xStdDev = 1, yMean = 0, yStdDev = 1) {
     const points = [];
     for (let i = 0; i < n; i++) {
       points.push({
+        label: `id-${i}`, 
         x: randomNormal(xMean, xStdDev),
-        y: randomNormal(yMean, yStdDev)
+        y: randomNormal(yMean, yStdDev),
       });
     }
     return points;
   }
 
-  
-export const ScatterplotNormalDistribChart = ChartTemplate.bind({});
 const ScatterplotNormalDistribChartArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
-        value: generateNormalDistribution(10000, 5, 2, 5, 2),
+        value: generateNormalDistribution(1000, 5, 2, 5, 2),
     },
     options: {
         labelColumn: 'label',
         series: [
             {
+                label: "Serie 1",
                 type: ChartSeriesType.Scatter,
                 valueColumn:"x",
                 indexAxis:"y",
-                label:"Group 1",
-                pointRadius: .08,
-                hitRadius: 5,
-                pointHoverRadius: 4,
-                pointBorderColor: "#00000000",
-                backgroundColor: 'rgba(255, 0, 0)',
-                dataLabels:{
-                    display:false
-                }
+                backgroundColor: COLORS.blue,
             },
         ],
-        legend: {
-            display: true,
-        },
         axis: {
             x: {
                 display: true,
+                title: {
+                    display: true,
+                    text: "Horizontal axis"
+                }, 
+                beginAtZero: true
             },
             y: {
                 display: true,
-            },
-            assemblage: {
-                stacked: false,
-                percentaged: false,
-            },
-        },
-        title: {
-            text: 'test with gap',
-        },
-    },
-};
-ScatterplotNormalDistribChart.args = ScatterplotNormalDistribChartArgs;
-
-function randomExponential(lambda :number) {
-    return -Math.log(1.0 - Math.random()) / lambda;
-  }
-  
-  function generateExponentialDistribution(n :number, lambda = 1, yRange = [0, 1]) {
-    const points = [];
-    for (let i = 0; i < n; i++) {
-      points.push({
-        x: randomExponential(lambda),
-        y: yRange[0] + Math.random() * (yRange[1] - yRange[0])
-      });
-    }
-    return points;
-  }
-  
-  export const ScatterplotExponentialDistribChart = ChartTemplate.bind({});
-const ScatterplotExponentialDistribChartArgs: Props<DataFrame, ChartOptions> = {
-    data: {
-        loading: false,
-        value: generateExponentialDistribution(1000, 10, [0, 10]),
-    },
-    options: {
-        labelColumn: 'label',
-        series: [
-            {
-                type: ChartSeriesType.Scatter,
-                valueColumn:"x",
-                indexAxis:"y",
-                label:"Group 1",
-                pointRadius: 5,
-                hitRadius: 5,
-                pointBorderColor: "#000000",
-                pointHoverRadius: 4,
-                backgroundColor: 'rgba(255, 0, 0, .5)',
-                dataLabels:{
-                    display:false
-                }
-            },
-        ],
-        legend: {
-            display: true,
-        },
-        axis: {
-            x: {
-                display: true,
-            },
-            y: {
-                display: true,
-            },
-            assemblage: {
-                stacked: false,
-                percentaged: false,
+                title: {
+                    display: true,
+                    text: "Vertical axis"
+                },
+                beginAtZero: true
             },
         },
         title: {
-            text: 'test with gap',
+            text: 'Scatterplot Chart - Normal distribution',
         },
     },
 };
-ScatterplotExponentialDistribChart.args = ScatterplotExponentialDistribChartArgs;
+export const ScatterplotNormalDistribChart = {
+    args: ScatterplotNormalDistribChartArgs, 
+    parameters: {chromatic: { disableSnapshot: true }}
+};

--- a/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
@@ -792,7 +792,7 @@ export const ScatterplotNormalDistribChart = ChartTemplate.bind({});
 const ScatterplotNormalDistribChartArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
-        value: generateNormalDistribution(1000, 5, 2, 5, 2),
+        value: generateNormalDistribution(10000, 5, 2, 5, 2),
     },
     options: {
         labelColumn: 'label',
@@ -802,11 +802,11 @@ const ScatterplotNormalDistribChartArgs: Props<DataFrame, ChartOptions> = {
                 valueColumn:"x",
                 indexAxis:"y",
                 label:"Group 1",
-                pointRadius: 5,
+                pointRadius: .08,
                 hitRadius: 5,
                 pointHoverRadius: 4,
                 pointBorderColor: "#00000000",
-                backgroundColor: 'rgba(255, 0, 0, .5)',
+                backgroundColor: 'rgba(255, 0, 0)',
                 dataLabels:{
                     display:false
                 }

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -168,7 +168,6 @@
             (chartOptions as Exclude<ChartConfiguration<'doughnut'>['options'], undefined>).cutout =
                 options.series[0].cutout;
         }
-        chartOptions.interaction = defaultValue(options.interaction,"");
         chartConfig = update(chartConfig, { options: { $set: chartOptions } });
     }
 

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -140,8 +140,11 @@
                                 return `${dataFrame[dataIndex].x}: ${format(parsed)}`;
                             }
                             if (seriesType === ChartSeriesType.Scatter) {
-                                prefix= `${label} `
-                                return prefix + `(x: ${format(parsed.x)} | y: ${format(parsed.y)})` + suffix;
+                                const formattedValues = `${format(parsed.x)}, ${format(parsed.y)}`;
+                                // e.g. dataset 1: (4.5, 54)
+                                if (prefix) return `${prefix}(${formattedValues})`;
+                                // 4.5, 54
+                                return formattedValues;
                             }
                         }
 

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -139,6 +139,10 @@
                                 // charts, the label is not the series legend, it's the category.
                                 return `${dataFrame[dataIndex].x}: ${format(parsed)}`;
                             }
+                            if (seriesType === ChartSeriesType.Scatter) {
+                                prefix= `${label} `
+                                return prefix + `(x: ${format(parsed.x)} | y: ${format(parsed.y)})` + suffix;
+                            }
                         }
 
                         return prefix + formattedValue + suffix;
@@ -164,6 +168,7 @@
             (chartOptions as Exclude<ChartConfiguration<'doughnut'>['options'], undefined>).cutout =
                 options.series[0].cutout;
         }
+        chartOptions.interaction = defaultValue(options.interaction,"");
         chartConfig = update(chartConfig, { options: { $set: chartOptions } });
     }
 

--- a/packages/visualizations/src/components/Chart/datasets.ts
+++ b/packages/visualizations/src/components/Chart/datasets.ts
@@ -104,14 +104,14 @@ export default function toDataset(df: DataFrame, s: ChartSeries): ChartDataset {
     if (s.type === 'scatter') {
         return {
             type: 'scatter',
-            label:s.label,
-            data: df.map((entry) => ({x: entry[s.indexAxis],y : entry[s.valueColumn]})),
-            backgroundColor: s.backgroundColor,
+            label: defaultValue(s.label, ''),
+            data: df.map((entry) => ({ x: entry[s.indexAxis], y: entry[s.valueColumn] })),
             datalabels: chartJsDataLabels(s.dataLabels),
-            pointRadius: defaultValue(s.pointRadius, 4),
-            pointHitRadius: defaultValue(s.hitRadius, 4.5),
-            pointBorderColor: defaultValue(s.pointBorderColor,'rgba(255,255,255,0)'),
-            pointHoverRadius:defaultValue(s.pointHoverRadius, 4),
+            backgroundColor: singleChartJsColor(s.backgroundColor),
+            pointRadius: defaultValue(s.pointRadius, 5),
+            pointHitRadius: defaultValue(s.pointHitRadius, 5),
+            pointHoverRadius: defaultValue(s.pointHoverRadius, 5),
+            pointBorderColor: defaultValue(s.pointBorderColor, 'rgba(255,255,255, 0)'),
         };
     }
     throw new Error('Unknown chart type');

--- a/packages/visualizations/src/components/Chart/datasets.ts
+++ b/packages/visualizations/src/components/Chart/datasets.ts
@@ -101,5 +101,18 @@ export default function toDataset(df: DataFrame, s: ChartSeries): ChartDataset {
         };
     }
 
+    if (s.type === 'scatter') {
+        return {
+            type: 'scatter',
+            label:s.label,
+            data: df.map((entry) => ({x: entry[s.valueColumn],y : entry[s.indexAxis]})),
+            backgroundColor: s.backgroundColor,
+            datalabels: chartJsDataLabels(s.dataLabels),
+            pointRadius: defaultValue(s.pointRadius, 3),
+            hitRadius: defaultValue(s.hitRadius, 3),
+            pointBorderColor: defaultValue(s.pointBorderColor,'rgb(255,255,255)'),
+            pointHoverRadius:defaultValue(s.pointHoverRadius, 3),
+        };
+    }
     throw new Error('Unknown chart type');
 }

--- a/packages/visualizations/src/components/Chart/datasets.ts
+++ b/packages/visualizations/src/components/Chart/datasets.ts
@@ -105,13 +105,13 @@ export default function toDataset(df: DataFrame, s: ChartSeries): ChartDataset {
         return {
             type: 'scatter',
             label:s.label,
-            data: df.map((entry) => ({x: entry[s.valueColumn],y : entry[s.indexAxis]})),
+            data: df.map((entry) => ({x: entry[s.indexAxis],y : entry[s.valueColumn]})),
             backgroundColor: s.backgroundColor,
             datalabels: chartJsDataLabels(s.dataLabels),
-            pointRadius: defaultValue(s.pointRadius, 3),
-            hitRadius: defaultValue(s.hitRadius, 3),
-            pointBorderColor: defaultValue(s.pointBorderColor,'rgb(255,255,255)'),
-            pointHoverRadius:defaultValue(s.pointHoverRadius, 3),
+            pointRadius: defaultValue(s.pointRadius, 4),
+            pointHitRadius: defaultValue(s.hitRadius, 4.5),
+            pointBorderColor: defaultValue(s.pointBorderColor,'rgba(255,255,255,0)'),
+            pointHoverRadius:defaultValue(s.pointHoverRadius, 4),
         };
     }
     throw new Error('Unknown chart type');

--- a/packages/visualizations/src/components/Chart/scales.ts
+++ b/packages/visualizations/src/components/Chart/scales.ts
@@ -81,6 +81,9 @@ export default function buildScales(options: ChartOptions): ChartJsChartOptions[
     // X Axis
     if (options.axis?.x) {
         scales.x = {
+            ...(options.axis.x.type === 'linear' && {
+                beginAtZero: defaultValue(options?.axis?.x?.beginAtZero, true),
+            }),
             stacked: options.axis?.assemblage?.stacked,
             max:
                 options?.axis?.x?.type === 'linear' && options.axis?.assemblage?.percentaged
@@ -130,6 +133,9 @@ export default function buildScales(options: ChartOptions): ChartJsChartOptions[
     // Y Axis
     if (options.axis?.y) {
         scales.y = {
+            ...(options.axis.y.type === 'linear' && {
+                beginAtZero: defaultValue(options?.axis?.y?.beginAtZero, true),
+            }),
             stacked: options.axis?.assemblage?.stacked,
             max:
                 options?.axis?.y?.type === 'linear' && options.axis?.assemblage?.percentaged

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -39,7 +39,6 @@ export interface ChartOptions {
     description?: string;
     /** Link button to source */
     source?: Source;
-    interaction?:Object
 }
 
 export interface GridLinesConfiguration {
@@ -215,7 +214,7 @@ export interface Scatter {
     type: ChartSeriesType.Scatter;
     valueColumn: string;
     label?: string;
-    indexAxis:string;
+    indexAxis: string;
     backgroundColor?: Color | Color[];
     borderColor?: Color | Color[];
     fill?: FillConfiguration;

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -39,6 +39,7 @@ export interface ChartOptions {
     description?: string;
     /** Link button to source */
     source?: Source;
+    interaction?:Object
 }
 
 export interface GridLinesConfiguration {
@@ -138,7 +139,7 @@ export interface DataLabelsConfiguration {
     padding?: number;
 }
 
-export type ChartSeries = Line | Bar | Pie | Radar | Doughnut;
+export type ChartSeries = Line | Bar | Pie | Radar | Doughnut | Scatter;
 
 export enum ChartSeriesType {
     Line = 'line',
@@ -146,6 +147,7 @@ export enum ChartSeriesType {
     Pie = 'pie',
     Radar = 'radar',
     Doughnut = 'doughnut',
+    Scatter = 'scatter',
 }
 
 export interface Line {
@@ -207,6 +209,24 @@ export interface Doughnut {
     backgroundColor?: Color | Color[];
     dataLabels?: DataLabelsConfiguration;
     indexAxis?: 'x' | 'y';
+}
+
+export interface Scatter {
+    type: ChartSeriesType.Scatter;
+    valueColumn: string;
+    label?: string;
+    indexAxis:string;
+    backgroundColor?: Color | Color[];
+    borderColor?: Color | Color[];
+    fill?: FillConfiguration;
+    dataLabels?: DataLabelsConfiguration;
+    tension?: number;
+    pointRadius?: number;
+    pointBorderColor?: string;
+    pointBackgroundColor?: Color | Color[];
+    borderWidth?: number;
+    borderDash?: number[];
+    spanGaps?: boolean | number;
 }
 
 export type FillMode = false | number | string | { value: number };

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -76,9 +76,18 @@ export interface CategoryCartesianAxisConfiguration extends BaseCartesianAxisCon
     type?: 'category';
 }
 
-export interface NumericCartesianAxisConfiguration extends BaseCartesianAxisConfiguration {
-    type: 'linear' | 'logarithmic';
+export interface LinearCartesianAxisConfiguration extends BaseCartesianAxisConfiguration {
+    type: 'linear';
+    beginAtZero?: boolean;
 }
+
+export interface LogarithmicCartesianAxisConfiguration extends BaseCartesianAxisConfiguration {
+    type: 'logarithmic';
+}
+
+export type NumericCartesianAxisConfiguration =
+    | LinearCartesianAxisConfiguration
+    | LogarithmicCartesianAxisConfiguration;
 
 export interface AxisTitleConfiguration {
     display?: boolean;

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -224,19 +224,13 @@ export interface Scatter {
     valueColumn: string;
     label?: string;
     indexAxis: string;
+    /** Point color */
     backgroundColor?: Color | Color[];
-    borderColor?: Color | Color[];
-    fill?: FillConfiguration;
-    dataLabels?: DataLabelsConfiguration;
-    tension?: number;
     pointRadius?: number;
-    hitRadius?:number;
-    pointHoverRadius:number;
+    pointHitRadius?: number;
+    pointHoverRadius?: number;
     pointBorderColor?: string;
-    pointBackgroundColor?: Color | Color[];
-    borderWidth?: number;
-    borderDash?: number[];
-    spanGaps?: boolean | number;
+    dataLabels?: DataLabelsConfiguration;
 }
 
 export type FillMode = false | number | string | { value: number };

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -222,6 +222,8 @@ export interface Scatter {
     dataLabels?: DataLabelsConfiguration;
     tension?: number;
     pointRadius?: number;
+    hitRadius?:number;
+    pointHoverRadius:number;
     pointBorderColor?: string;
     pointBackgroundColor?: Color | Color[];
     borderWidth?: number;

--- a/packages/visualizations/src/components/utils/formatter.ts
+++ b/packages/visualizations/src/components/utils/formatter.ts
@@ -22,7 +22,7 @@ export function defaultCompactLegendNumberFormat(value: number): string {
 }
 
 export function assureMaxLength(value: string, maxLength: number) {
-    if (value.length > maxLength) {
+    if (value && value.length > maxLength) {
         return `${value.substring(0, maxLength)}...`;
     }
     return value;

--- a/packages/visualizations/src/components/utils/formatter.ts
+++ b/packages/visualizations/src/components/utils/formatter.ts
@@ -22,7 +22,7 @@ export function defaultCompactLegendNumberFormat(value: number): string {
 }
 
 export function assureMaxLength(value: string, maxLength: number) {
-    if (value && value.length > maxLength) {
+    if (value.length > maxLength) {
         return `${value.substring(0, maxLength)}...`;
     }
     return value;


### PR DESCRIPTION
## Summary

The goal for this PR is to add a new type of chart: [Scatter](https://www.chartjs.org/docs/latest/charts/scatter.html)

⚠️  **This is a very simple implementation, which forms the basis for iterating according to future needs.**

⚠️  Commits will be purged before merge

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-42061](https://app.shortcut.com/opendatasoft/story/42061).

![Screenshot 2023-09-08 at 11 37 27](https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/61f20b1b-1370-47ef-b958-ffa5079a235a)

### Changes

- Update `NumericCartesianAxisConfiguration` types to allow linear Cartesian axis to begin at zero
   **x and y axis doesn't begins at zero by default (so no breaking changes)**
- Handle the scatter case for tooltip and dataset builds

#### Breaking Changes

none


### Changelog

Add new chart type: scatter

## Review checklist

- [x] Description is complete
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
