### PR TITLE
feat: Add Record endpoint in api-client

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,7 @@ _special cases that are not widely known_
 ## Review checklist
 
 - [ ] Description is complete
+- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
 - [ ] 2 reviewers (1 if trivial)
 - [ ] Tests coverage has improved
 - [ ] Code is ready for a release on NPM

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -177,6 +177,13 @@ client.get(
         .datasets()
         .select('dataset_id, records_count')
 );
+
+// ../catalog/datasets/my-dataset/records/2ee92a48178f784a5babfc06cb42d210cab57f55/
+client.get(
+    fromCatalog()
+        .dataset('my-dataset')
+        .record('2ee92a48178f784a5babfc06cb42d210cab57f55')
+);
 ```
 
 The `Query` interface expose convenient parameters of an API request.


### PR DESCRIPTION
## Summary

The goal for this PR is to catch-up the merged "support record endpoint in api-client" PR (#183) with conventional commits.

### Changes

I added a small bit of doc, which fits what currently exists in the README. It's starting to look a bit "light" if we consider this a doc, but we'll see that later.
I edited the PR template to mention conventional commits.

## Open discussion
It would be nice indeed to only offer ODSQL features (`.where()`, `.limit()` etc) on endpoints that support it, but this doesn't seem trivial at all, especially if we want to do it right and really support the right parameters on each endpoint. I think it's firmly out of scope for this one.


## Review checklist

- [ ] Description is complete
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
