### PR TITLE
[sc-43517] Expose config for Bar and Column charts with groups

### DIFF
--- a/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
@@ -375,6 +375,104 @@ const BarChartPercentageArgs: Props<DataFrame, ChartOptions> = {
 };
 BarChartPercentage.args = BarChartPercentageArgs;
 
+export const BarChartStackedGroups = ChartTemplate.bind({});
+const BarChartStackedGroupsArgs: Props<DataFrame, ChartOptions> = {
+    data: {
+        loading: false,
+        value: [
+            { series_001: null, series_002: 20, series_003: 50, series_004: 11, x: 'Acer' },
+            { series_001: 22, series_002: 28, series_003: 27, series_004: 67, x: 'Aesculus' },
+            { series_001: 18, series_002: 18, series_003: 11, series_004: 10, x: 'Alnus' },
+            { series_001: 11, series_002: 11, series_003: 33, series_004: 21, x: 'Araucaria' },
+            { series_001: 20, series_002: 20, series_003: 9, series_004: 22, x: 'Betula' },
+            { series_001: 21, series_002: 21, series_003: 21, series_004: 18.14, x: 'Calocedrus' },
+            { series_001: 10, series_002: 9, series_003: 22, series_004: 10, x: 'Catalpa' },
+            { series_001: 21, series_002: 19.375, series_003: 15, series_004: 12, x: 'Cedrus' },
+            { series_001: 18, series_002: 15, series_003: 20, series_004: 27, x: 'Celtis' },
+        ],
+    },
+    options: {
+        labelColumn: 'x',
+        title: {
+            text: 'Bar Chart - Stacked Groups',
+        },
+        series: [
+            {
+                type: ChartSeriesType.Bar,
+                valueColumn: 'series_001',
+                indexAxis: 'y',
+                stack: 'stack_0',
+                borderColor: 'rgba(255, 0, 0, 1)',
+                backgroundColor: 'rgba(255, 0, 0, 0.5)',
+                dataLabels: {
+                    display: false,
+                    color: 'rgba(255, 0, 0, 1)',
+                },
+            },
+            {
+                type: ChartSeriesType.Bar,
+                valueColumn: 'series_002',
+                indexAxis: 'y',
+                stack: 'stack_0',
+                borderColor: 'rgba(38, 56, 145, 1)',
+                backgroundColor: 'rgba(38, 56, 145, 0.5)',
+                dataLabels: {
+                    display: false,
+                    color: 'rgba(38, 56, 145, 1)',
+                },
+            },
+            {
+                type: ChartSeriesType.Bar,
+                valueColumn: 'series_003',
+                indexAxis: 'y',
+                stack: 'stack_1',
+                borderColor: 'rgba(218, 30, 127, 0.8)',
+                backgroundColor: 'rgba(218, 30, 127, 0.8)',
+                dataLabels: {
+                    display: false,
+                    color: 'rgba(218, 30, 127, 0.8)',
+                },
+            },
+            {
+                type: ChartSeriesType.Bar,
+                valueColumn: 'series_004',
+                indexAxis: 'y',
+                stack: 'stack_1',
+                borderColor: 'rgba(30, 218, 147, 0.8)',
+                backgroundColor: 'rgba(30, 218, 147, 0.8)',
+                dataLabels: {
+                    display: false,
+                    color: 'rgba(30, 218, 147, 0.8)',
+                },
+            },
+        ],
+        axis: {
+            x: {
+                display: true,
+                type: 'linear',
+                gridLines: {
+                    display: true,
+                },
+                ticks: {
+                    display: true,
+                },
+            },
+            y: {
+                display: true,
+                gridLines: {
+                    display: false,
+                },
+                type: 'category',
+            },
+            assemblage: {
+                stacked: true,
+                percentaged: false,
+            },
+        },
+    },
+};
+BarChartStackedGroups.args = BarChartStackedGroupsArgs;
+
 export const ColumnChartStacked = ChartTemplate.bind({});
 const ColumnChartStackedArgs: Props<DataFrame, ChartOptions> = {
     data: {
@@ -516,3 +614,99 @@ const ColumnChartPercentageArgs: Props<DataFrame, ChartOptions> = {
     },
 };
 ColumnChartPercentage.args = ColumnChartPercentageArgs;
+
+
+export const ColumnChartStackedGroups = ChartTemplate.bind({});
+const ColumnChartStackedGroupsArgs: Props<DataFrame, ChartOptions> = {
+    data: {
+        loading: false,
+        value: [
+            { series_001: null, series_002: 20, series_003: 50, series_004: 11, x: 'Acer' },
+            { series_001: 22, series_002: 28, series_003: 27, series_004: 67, x: 'Aesculus' },
+            { series_001: 18, series_002: 18, series_003: 11, series_004: 10, x: 'Alnus' },
+            { series_001: 11, series_002: 11, series_003: 33, series_004: 21, x: 'Araucaria' },
+            { series_001: 20, series_002: 20, series_003: 9, series_004: 22, x: 'Betula' },
+            { series_001: 21, series_002: 21, series_003: 21, series_004: 18.14, x: 'Calocedrus' },
+            { series_001: 10, series_002: 9, series_003: 22, series_004: 10, x: 'Catalpa' },
+            { series_001: 21, series_002: 19.375, series_003: 15, series_004: 12, x: 'Cedrus' },
+            { series_001: 18, series_002: 15, series_003: 20, series_004: 27, x: 'Celtis' },
+        ],
+    },
+    options: {
+        labelColumn: 'x',
+        title: {
+            text: 'Column Chart - Stacked Groups',
+        },
+        series: [
+            {
+                type: ChartSeriesType.Bar,
+                valueColumn: 'series_001',
+                borderColor: 'rgba(255, 0, 0, 1)',
+                backgroundColor: 'rgba(255, 0, 0, 0.5)',
+                dataLabels: {
+                    display: false,
+                    color: 'rgba(255, 0, 0, 1)',
+                },
+                stack: 'stack_0',
+            },
+            {
+                type: ChartSeriesType.Bar,
+                valueColumn: 'series_002',
+                borderColor: 'rgba(38, 56, 145, 1)',
+                backgroundColor: 'rgba(38, 56, 145, 0.5)',
+                dataLabels: {
+                    display: false,
+                    color: 'rgba(38, 56, 145, 1)',
+                },
+                stack: 'stack_0',
+            },
+            {
+                type: ChartSeriesType.Bar,
+                valueColumn: 'series_003',
+                stack: 'stack_1',
+                borderColor: 'rgba(218, 30, 127, 0.8)',
+                backgroundColor: 'rgba(218, 30, 127, 0.8)',
+                dataLabels: {
+                    display: false,
+                    color: 'rgba(218, 30, 127, 0.8)',
+                },
+            },
+            {
+                type: ChartSeriesType.Bar,
+                valueColumn: 'series_004',
+                stack: 'stack_1',
+                borderColor: 'rgba(30, 218, 147, 0.8)',
+                backgroundColor: 'rgba(30, 218, 147, 0.8)',
+                dataLabels: {
+                    display: false,
+                    color: 'rgba(30, 218, 147, 0.8)',
+                },
+            },
+        ],
+        axis: {
+            x: {
+                display: true,
+                offset: true,
+                gridLines: {
+                    display: false,
+                },
+                type: 'category',
+            },
+            y: {
+                display: true,
+                type: 'linear',
+                gridLines: {
+                    display: true,
+                },
+                ticks: {
+                    display: true,
+                },
+            },
+            assemblage: {
+                stacked: true,
+                percentaged: false,
+            },
+        },
+    },
+};
+ColumnChartStackedGroups.args = ColumnChartStackedGroupsArgs;

--- a/packages/visualizations/src/components/Chart/datasets.ts
+++ b/packages/visualizations/src/components/Chart/datasets.ts
@@ -46,6 +46,7 @@ export default function toDataset(df: DataFrame, s: ChartSeries): ChartDataset {
             barPercentage: defaultValue(s.barPercentage, 0.9),
             categoryPercentage: defaultValue(s.categoryPercentage, 0.8),
             datalabels: chartJsDataLabels(s.dataLabels),
+            stack: s.stack,
         };
     }
 

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -176,6 +176,7 @@ export interface Bar {
     categoryPercentage?: number;
     barPercentage?: number;
     dataLabels?: DataLabelsConfiguration;
+    stack?: string;
 }
 
 export interface Pie {


### PR DESCRIPTION
## Summary

The goal for this PR is to expose the `stack` property of Chart.js, to be able to configure [Bar and Column charts with groups](https://www.chartjs.org/docs/latest/samples/bar/stacked-groups.html). It also update storybook with demonstration stories.

<img width="830" alt="Capture d’écran 2023-09-15 à 17 57 07" src="https://github.com/opendatasoft/ods-dataviz-sdk/assets/5773072/4ccf712d-ff65-49d2-b366-4b4e2b5ff697">

<img width="1032" alt="Capture d’écran 2023-09-15 à 16 25 46" src="https://github.com/opendatasoft/ods-dataviz-sdk/assets/5773072/3dd42091-3dcc-410e-82a4-46dc439fc09c">

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-43517](https://app.shortcut.com/opendatasoft/story/43517/sdk-expose-api-for-stacked-y-bar).

### Changes

- Expose chart.js `stack` property for Bar charts.
- Update AxisAssemblages stories with stories for grouped bar and bar charts. 

#### Breaking Changes

none

### Changelog

In the Chart component, it is now possible to configure Bar and Column charts with groups using the `stack` property.

## Open discussion

?

## To be tested

- No impact on existing bar and column charts
- works as expected

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [x] Tests coverage has improved
- [x] Code is ready for a release on NPM
