### PR TITLE
[FIX][POI Maps]: add map resize observer

### DIFF
--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -27,7 +27,7 @@
 
     // Lifecycle
     onMount(() => map.initialize(style, container, { bounds: bbox as LngLatBoundsLike }));
-    onDestroy(() => map.remove());
+    onDestroy(() => map.destroy());
 </script>
 
 <figure class="map-card maps-container" style={cssVarStyles}>


### PR DESCRIPTION
## Summary

The goal for this PR is to update the size of the map when its container changes

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-43538](https://app.shortcut.com/opendatasoft/story/43538).

### Changes

Add a resize observer 

#### Breaking Changes

none
### Changelog

none

## Open discussion

none

## To be tested

Inspect the HTML document with the id="map", change its width/height. Map should resize

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
