### PR TITLE
[FIX][POI Map] Improve large content in popup

### DIFF
--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -104,6 +104,14 @@
         margin: 0;
     }
     /* To add classes programmatically in svelte we will use a global selector. We place it inside a local selector to obtain some encapsulation and avoid side effects */
+    .map-card :global(.poi-map__popup) {
+        /* To be above map controls (z-index: 2)*/
+        z-index: 3;
+        /* 26px is for its padding */
+        max-height: calc(100% - 26px);
+        height: auto;
+        overflow-y: auto;
+    }
     .map-card :global(.poi-map__popup.poi-map__popup--as-sidebar) {
         /* TO DO: add common stylesheet */
         transform: translate(13px, 13px) !important;


### PR DESCRIPTION
## Summary

The goal for this PR is to improve how large popup content is rendered

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-43612](https://app.shortcut.com/opendatasoft/story/43612).

https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/534b1e39-9bbf-4099-b908-8dd428056558

### Changes

This is a minimal change that has a impact only on the height of the tooltip.
**We are waiting for the design to set new rules.
`Maplibre.Popup` will probably be replace by a custom DOM element outside of map.**

Tooltip will never vertically overflow. It works well for the popup is 'sidebar' layout. Less for the 'tooltip' style.


## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
