### PR TITLE
fix: Use same typing for `indexAxis` as other charts series

### DIFF
--- a/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/AxisAssemblages/AxisAssemblages.stories.tsx
@@ -705,8 +705,8 @@ const ScatterPlotChartArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
         value: [
-            {label: 'id-0', x: -10, y: 20}, 
-            {label: 'id-1', x: 20, y: -10}, 
+            {label: 'id-0', x: -10, y: 20},
+            {label: 'id-1', x: 20, y: -10},
             {label: 'id-2', x: 5, y: 2},
             {label: 'id-3', x: 7, y: 3}
         ],
@@ -760,7 +760,7 @@ function generateNormalDistribution(n: number, xMean = 0, xStdDev = 1, yMean = 0
     const points = [];
     for (let i = 0; i < n; i++) {
       points.push({
-        label: `id-${i}`, 
+        label: `id-${i}`,
         x: randomNormal(xMean, xStdDev),
         y: randomNormal(yMean, yStdDev),
       });
@@ -779,8 +779,8 @@ const ScatterplotNormalDistribChartArgs: Props<DataFrame, ChartOptions> = {
             {
                 label: "Serie 1",
                 type: ChartSeriesType.Scatter,
-                valueColumn:"x",
-                indexAxis:"y",
+                valueColumn:"y",
+                indexAxis:"x",
                 backgroundColor: COLORS.blue,
             },
         ],
@@ -790,7 +790,7 @@ const ScatterplotNormalDistribChartArgs: Props<DataFrame, ChartOptions> = {
                 title: {
                     display: true,
                     text: "Horizontal axis"
-                }, 
+                },
                 beginAtZero: true
             },
             y: {
@@ -808,6 +808,6 @@ const ScatterplotNormalDistribChartArgs: Props<DataFrame, ChartOptions> = {
     },
 };
 export const ScatterplotNormalDistribChart = {
-    args: ScatterplotNormalDistribChartArgs, 
+    args: ScatterplotNormalDistribChartArgs,
     parameters: {chromatic: { disableSnapshot: true }}
 };

--- a/packages/visualizations/src/components/Chart/datasets.ts
+++ b/packages/visualizations/src/components/Chart/datasets.ts
@@ -114,7 +114,10 @@ export default function toDataset(df: DataFrame, s: ChartSeries): ChartDataset {
         return {
             type: 'scatter',
             label: defaultValue(s.label, ''),
-            data: df.map((entry) => ({ x: entry[defaultValue(s.indexAxis, 'x')], y: entry[defaultValue(s.valueColumn, 'y')] })),
+            data: df.map((entry) => ({
+                x: entry[defaultValue(s.indexAxis, 'x')],
+                y: entry[defaultValue(s.valueColumn, 'y')],
+            })),
             datalabels: chartJsDataLabels(s.dataLabels),
             backgroundColor: singleChartJsColor(s.backgroundColor),
             pointRadius: defaultValue(s.pointRadius, 5),

--- a/packages/visualizations/src/components/Chart/datasets.ts
+++ b/packages/visualizations/src/components/Chart/datasets.ts
@@ -114,7 +114,7 @@ export default function toDataset(df: DataFrame, s: ChartSeries): ChartDataset {
         return {
             type: 'scatter',
             label: defaultValue(s.label, ''),
-            data: df.map((entry) => ({ x: entry[s.indexAxis], y: entry[s.valueColumn] })),
+            data: df.map((entry) => ({ x: entry[defaultValue(s.indexAxis, 'x')], y: entry[defaultValue(s.valueColumn, 'y')] })),
             datalabels: chartJsDataLabels(s.dataLabels),
             backgroundColor: singleChartJsColor(s.backgroundColor),
             pointRadius: defaultValue(s.pointRadius, 5),

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -223,7 +223,7 @@ export interface Scatter {
     type: ChartSeriesType.Scatter;
     valueColumn: string;
     label?: string;
-    indexAxis: string;
+    indexAxis?: 'x' | 'y';
     /** Point color */
     backgroundColor?: Color | Color[];
     pointRadius?: number;


### PR DESCRIPTION
## Summary

This pull request introduces several changes to the `visualizations-react` and `visualizations` packages, specifically targeting scatter plot chart configurations. The changes primarily focus on code refactoring and minor enhancements for better maintainability and flexibility.

Fixes the error on the platform:

```shell
    Type '{ type: ChartSeriesType.Doughnut; cutout: string; valueColumn: string; label?: string | undefined; indexAxis: string; backgroundColor?: string | string[] | undefined; pointRadius?: number | undefined; pointHitRadius?: number | undefined; pointHoverRadius?: number | undefined; pointBorderColor?: string | undefined; d...' is not assignable to type 'ChartSeries'.
      Type '{ type: ChartSeriesType.Doughnut; cutout: string; valueColumn: string; label?: string | undefined; indexAxis: string; backgroundColor?: string | string[] | undefined; pointRadius?: number | undefined; pointHitRadius?: number | undefined; pointHoverRadius?: number | undefined; pointBorderColor?: string | undefined; d...' is not assignable to type 'Doughnut'.
        Types of property 'indexAxis' are incompatible.
          Type 'string' is not assignable to type '"x" | "y" | undefined'.
    364 |         return {
    365 |             ...baseConfig,
  > 366 |             series: baseConfig.series.map(serie => ({
        |             ^^^^^^
    367 |                 ...serie,
    368 |                 type: ChartSeriesType.Doughnut,
    369 |                 cutout: CUTOUT_VALUES[configuration.styles?.cutout || DOUGHNUT_CUTOUT.Small],
```

### Changes

- **Argument Swapping**: In `AxisAssemblages.stories.tsx`, the `valueColumn` and `indexAxis` fields have been swapped for better consistency with the actual data.
- **Flexible Defaults**: Modified the `toDataset` function in `datasets.ts` to use default values for `indexAxis` and `valueColumn` when they are not explicitly provided.
- **Type Enhancement**: Changed `indexAxis` type definition in `types.ts` to be optional and limited to either 'x' or 'y' to match other chart series types.
- **Code Formatting**: Removed trailing whitespaces in `AxisAssemblages.stories.tsx` to adhere to linting rules.

#### Breaking Changes

/ 

### Changelog


/ 

## Open discussion

/ 

## To be tested

/ 

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
