### PR TITLE
[FEATURE][POI MAP] Add `zoom`and `center` options

### DIFF
--- a/packages/visualizations/src/components/MapPoi/Map.svelte
+++ b/packages/visualizations/src/components/MapPoi/Map.svelte
@@ -35,10 +35,10 @@
         interactive,
     } = getMapOptions(options));
 
-    let bbox = createDeepEqual(_bbox);
-    let center = createDeepEqual(_center);
-    $: bbox.set(_bbox);
-    $: center.set(_center);
+    const bbox = createDeepEqual(_bbox);
+    const center = createDeepEqual(_center);
+    $: bbox.update(_bbox);
+    $: center.update(_center);
 </script>
 
 <div>

--- a/packages/visualizations/src/components/MapPoi/Map.svelte
+++ b/packages/visualizations/src/components/MapPoi/Map.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { BBox } from 'geojson';
+    import createDeepEqual from '../../stores/createDeepEqual';
 
     import MapRender from './MapRender.svelte';
 
@@ -12,16 +12,10 @@
         getPopupsConfiguration,
         getMapOptions,
     } from './utils';
-    import type { Center, PoiMapData, PoiMapOptions } from './types';
+    import type { PoiMapData, PoiMapOptions } from './types';
 
     export let data: Async<PoiMapData>;
     export let options: PoiMapOptions;
-
-    let bbox: BBox;
-    let previousBbox: BBox;
-
-    let center: Center;
-    let previousCenter: Center;
 
     $: style = getMapStyle(options.style);
     $: sources = getMapSources(data.value?.sources);
@@ -29,9 +23,9 @@
     $: popupsConfiguration = getPopupsConfiguration(data.value?.layers);
 
     $: ({
-        bbox: currentBbox,
+        bbox: _bbox,
         zoom,
-        center: currentCenter,
+        center: _center,
         title,
         subtitle,
         description,
@@ -41,32 +35,10 @@
         interactive,
     } = getMapOptions(options));
 
-    /*
-     * As options is an object, current bbox updates when options changes
-     * We want to trigger an update to MapRender only if bbox value changes, not its reference.
-     */
-    $: {
-        // Update bbox only if different from previous bbox
-        if (
-            currentBbox &&
-            (!previousBbox || currentBbox.some((bound, index) => bound !== previousBbox[index]))
-        ) {
-            bbox = currentBbox;
-            previousBbox = currentBbox;
-        }
-    }
-
-    // Same thing as above for center
-    $: {
-        if (
-            currentCenter &&
-            (!previousCenter ||
-                currentCenter.some((point, index) => point !== previousCenter[index]))
-        ) {
-            center = currentCenter;
-            previousCenter = currentCenter;
-        }
-    }
+    let bbox = createDeepEqual(_bbox);
+    let center = createDeepEqual(_center);
+    $: bbox.set(_bbox);
+    $: center.set(_center);
 </script>
 
 <div>
@@ -76,8 +48,8 @@
             {sources}
             {layers}
             {popupsConfiguration}
-            {bbox}
-            {center}
+            bbox={$bbox}
+            center={$center}
             {zoom}
             {title}
             {subtitle}

--- a/packages/visualizations/src/components/MapPoi/Map.svelte
+++ b/packages/visualizations/src/components/MapPoi/Map.svelte
@@ -12,12 +12,16 @@
         getPopupsConfiguration,
         getMapOptions,
     } from './utils';
-    import type { PoiMapData, PoiMapOptions } from './types';
+    import type { Center, PoiMapData, PoiMapOptions } from './types';
 
     export let data: Async<PoiMapData>;
     export let options: PoiMapOptions;
+
     let bbox: BBox;
     let previousBbox: BBox;
+
+    let center: Center;
+    let previousCenter: Center;
 
     $: style = getMapStyle(options.style);
     $: sources = getMapSources(data.value?.sources);
@@ -26,6 +30,8 @@
 
     $: ({
         bbox: currentBbox,
+        zoom,
+        center: currentCenter,
         title,
         subtitle,
         description,
@@ -46,6 +52,18 @@
             previousBbox = currentBbox;
         }
     }
+
+    // Same thing as above for center
+    $: {
+        if (
+            currentCenter &&
+            (!previousCenter ||
+                currentCenter.some((point, index) => point !== previousCenter[index]))
+        ) {
+            center = currentCenter;
+            previousCenter = currentCenter;
+        }
+    }
 </script>
 
 <div>
@@ -56,6 +74,8 @@
             {layers}
             {popupsConfiguration}
             {bbox}
+            {center}
+            {zoom}
             {title}
             {subtitle}
             {description}

--- a/packages/visualizations/src/components/MapPoi/Map.svelte
+++ b/packages/visualizations/src/components/MapPoi/Map.svelte
@@ -47,7 +47,10 @@
      */
     $: {
         // Update bbox only if different from previous bbox
-        if (!previousBbox || currentBbox.some((bound, index) => bound !== previousBbox[index])) {
+        if (
+            currentBbox &&
+            (!previousBbox || currentBbox.some((bound, index) => bound !== previousBbox[index]))
+        ) {
             bbox = currentBbox;
             previousBbox = currentBbox;
         }

--- a/packages/visualizations/src/components/MapPoi/Map.svelte
+++ b/packages/visualizations/src/components/MapPoi/Map.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+    import type { BBox } from 'geojson';
+
     import MapRender from './MapRender.svelte';
 
     import type { Async } from '../../types';
@@ -14,18 +16,54 @@
 
     export let data: Async<PoiMapData>;
     export let options: PoiMapOptions;
+    let bbox: BBox;
+    let previousBbox: BBox;
 
     $: style = getMapStyle(options.style);
     $: sources = getMapSources(data.value?.sources);
     $: layers = getMapLayers(data.value?.layers);
     $: popupsConfiguration = getPopupsConfiguration(data.value?.layers);
 
-    $: computedOptions = getMapOptions(options);
+    $: ({
+        bbox: currentBbox,
+        title,
+        subtitle,
+        description,
+        legend,
+        sourceLink,
+        aspectRatio,
+        interactive,
+    } = getMapOptions(options));
+
+    /*
+     * As options is an object, current bbox updates when options changes
+     * We want to trigger an update to MapRender only if bbox value changes, not its reference.
+     */
+    $: {
+        // Update bbox only if different from previous bbox
+        if (!previousBbox || currentBbox.some((bound, index) => bound !== previousBbox[index])) {
+            bbox = currentBbox;
+            previousBbox = currentBbox;
+        }
+    }
 </script>
 
 <div>
     {#key style}
-        <MapRender {style} {sources} {layers} {popupsConfiguration} {...computedOptions} />
+        <MapRender
+            {style}
+            {sources}
+            {layers}
+            {popupsConfiguration}
+            {bbox}
+            {title}
+            {subtitle}
+            {description}
+            {legend}
+            {sourceLink}
+            {aspectRatio}
+            {interactive}
+        />
     {/key}
 </div>
 

--- a/packages/visualizations/src/components/MapPoi/Map.ts
+++ b/packages/visualizations/src/components/MapPoi/Map.ts
@@ -10,7 +10,7 @@ import maplibregl, {
 } from 'maplibre-gl';
 
 import { POPUP_OPTIONS } from './constants';
-import type { Center, PopupsConfiguration } from './types';
+import type { PopupsConfiguration, CenterZoomOptions } from './types';
 
 type MapFunction = (map: maplibregl.Map) => unknown;
 
@@ -240,21 +240,11 @@ export default class MapPOI {
     }
 
     /**
-     * Sets the map's zoom level.
-     * @param zoom
+     * Changes any combination of center and zoom without an animated transition.
+     * The map will retain its current values for any details not specified in options
      */
-    setZoom(zoom?: number) {
-        if (zoom === undefined) return;
-        this.queue((map) => map.setZoom(zoom));
-    }
-
-    /**
-     * Sets the map's geographical centerpoint.
-     * @param center
-     */
-    setCenter(center?: Center) {
-        if (center === undefined) return;
-        this.queue((map) => map.setCenter(center));
+    jumpTo(options: CenterZoomOptions) {
+        this.queue((map) => map.jumpTo(options));
     }
 
     setPopupsConfiguration(config: PopupsConfiguration) {

--- a/packages/visualizations/src/components/MapPoi/Map.ts
+++ b/packages/visualizations/src/components/MapPoi/Map.ts
@@ -9,7 +9,7 @@ import maplibregl, {
     StyleSpecification,
 } from 'maplibre-gl';
 
-import { DEFAULT_MAP_CENTER, POPUP_OPTIONS } from './constants';
+import { POPUP_OPTIONS } from './constants';
 import type { Center, PopupsConfiguration } from './types';
 
 type MapFunction = (map: maplibregl.Map) => unknown;
@@ -166,7 +166,7 @@ export default class MapPOI {
         container: HTMLElement,
         options: Omit<MapOptions, 'style' | 'container'>
     ) {
-        this.map = new maplibregl.Map({ style, container, center: DEFAULT_MAP_CENTER, ...options });
+        this.map = new maplibregl.Map({ style, container, ...options });
 
         this.queue((map) => this.initializeMapResizer(map, container));
 

--- a/packages/visualizations/src/components/MapPoi/Map.ts
+++ b/packages/visualizations/src/components/MapPoi/Map.ts
@@ -10,7 +10,7 @@ import maplibregl, {
 } from 'maplibre-gl';
 
 import { DEFAULT_MAP_CENTER, POPUP_OPTIONS } from './constants';
-import type { PopupsConfiguration } from './types';
+import type { Center, PopupsConfiguration } from './types';
 
 type MapFunction = (map: maplibregl.Map) => unknown;
 
@@ -237,6 +237,24 @@ export default class MapPOI {
                 padding: 40,
             });
         });
+    }
+
+    /**
+     * Sets the map's zoom level.
+     * @param zoom
+     */
+    setZoom(zoom?: number) {
+        if (zoom === undefined) return;
+        this.queue((map) => map.setZoom(zoom));
+    }
+
+    /**
+     * Sets the map's geographical centerpoint.
+     * @param center
+     */
+    setCenter(center?: Center) {
+        if (center === undefined) return;
+        this.queue((map) => map.setCenter(center));
     }
 
     setPopupsConfiguration(config: PopupsConfiguration) {

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -19,6 +19,8 @@
 
     // Options
     export let bbox: BBox;
+    export let zoom: number | undefined;
+    export let center: [number, number] | undefined;
     export let aspectRatio: number;
     export let interactive: boolean;
     export let title: string | undefined;
@@ -40,10 +42,20 @@
     $: map.setBbox(bbox);
     $: map.setSourcesAndLayers(sources, layers);
     $: map.setPopupsConfiguration(popupsConfiguration);
+    $: map.setZoom(zoom);
+    $: map.setCenter(center);
     $: cssVarStyles = `--aspect-ratio:${aspectRatio};`;
 
     // Lifecycle
-    onMount(() => map.initialize(style, container, { bounds: bbox as LngLatBoundsLike }));
+    onMount(() => {
+        const options = {
+            bounds: bbox as LngLatBoundsLike,
+            // The map doesn't seems to accept undefined values for center and zoom
+            ...(center ? { center } : null),
+            ...(Number.isInteger(zoom) ? { zoom } : null),
+        };
+        map.initialize(style, container, options);
+    });
     onDestroy(() => map.destroy());
 </script>
 

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -18,7 +18,7 @@
     export let layers: StyleSpecification['layers'];
 
     // Options
-    export let bbox: BBox;
+    export let bbox: BBox | undefined;
     export let zoom: number | undefined;
     export let center: [number, number] | undefined;
     export let aspectRatio: number;

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
     import type { BBox } from 'geojson';
-    import type { LngLatBoundsLike, MapOptions, StyleSpecification } from 'maplibre-gl';
+    import type { LngLatBoundsLike, LngLatLike, MapOptions, StyleSpecification } from 'maplibre-gl';
     import { onDestroy, onMount } from 'svelte';
     import CategoryLegend from '../Legend/CategoryLegend.svelte';
     import type { CategoryLegend as CategoryLegendType } from '../Legend/types';
@@ -10,6 +10,7 @@
     import type { Source } from '../types';
 
     import Map from './Map';
+    import { getCenterZoomOptions } from './utils';
     import type { PopupsConfiguration } from './types';
 
     // Base style, sources and layers
@@ -20,7 +21,7 @@
     // Options
     export let bbox: BBox | undefined;
     export let zoom: number | undefined;
-    export let center: [number, number] | undefined;
+    export let center: LngLatLike | undefined;
     export let aspectRatio: number;
     export let interactive: boolean;
     export let title: string | undefined;
@@ -42,17 +43,14 @@
     $: map.setBbox(bbox);
     $: map.setSourcesAndLayers(sources, layers);
     $: map.setPopupsConfiguration(popupsConfiguration);
-    $: map.setZoom(zoom);
-    $: map.setCenter(center);
+    $: map.jumpTo(getCenterZoomOptions({ zoom, center }));
     $: cssVarStyles = `--aspect-ratio:${aspectRatio};`;
 
     // Lifecycle
     onMount(() => {
         const options = {
             bounds: bbox as LngLatBoundsLike,
-            // The map doesn't seems to accept undefined values for center and zoom
-            ...(center ? { center } : null),
-            ...(Number.isInteger(zoom) ? { zoom } : null),
+            ...getCenterZoomOptions({ zoom, center }),
         };
         map.initialize(style, container, options);
     });

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -42,10 +42,6 @@
     $: map.setPopupsConfiguration(popupsConfiguration);
     $: cssVarStyles = `--aspect-ratio:${aspectRatio};`;
 
-    $: if (interactive === false) {
-        map.setBbox(bbox);
-    }
-
     // Lifecycle
     onMount(() => map.initialize(style, container, { bounds: bbox as LngLatBoundsLike }));
     onDestroy(() => map.destroy());

--- a/packages/visualizations/src/components/MapPoi/constants.ts
+++ b/packages/visualizations/src/components/MapPoi/constants.ts
@@ -1,5 +1,4 @@
-import type { BBox } from 'geojson';
-import type { LngLatLike, PopupOptions, StyleSpecification } from 'maplibre-gl';
+import type { PopupOptions, StyleSpecification } from 'maplibre-gl';
 import type { Color } from '../types';
 
 export const DEFAULT_BASEMAP_STYLE: StyleSpecification = {
@@ -9,13 +8,9 @@ export const DEFAULT_BASEMAP_STYLE: StyleSpecification = {
     layers: [],
 };
 
-export const DEFAULT_BBOX: BBox = [180, 90, -180, -90];
-
 export const DEFAULT_ASPECT_RATIO = 1;
 
 export const DEFAULT_DARK_GREY: Color = '#515457';
-
-export const DEFAULT_MAP_CENTER: LngLatLike = [0, 0];
 
 export const POPUP_OPTIONS: PopupOptions = {
     className: 'poi-map__popup',

--- a/packages/visualizations/src/components/MapPoi/types.ts
+++ b/packages/visualizations/src/components/MapPoi/types.ts
@@ -1,10 +1,13 @@
-import type { CircleLayerSpecification, StyleSpecification, GeoJSONFeature } from 'maplibre-gl';
+import type {
+    CircleLayerSpecification,
+    StyleSpecification,
+    GeoJSONFeature,
+    LngLatLike,
+} from 'maplibre-gl';
 import type { BBox, GeoJsonProperties } from 'geojson';
 
 import type { Color, Source } from '../types';
 import type { CategoryLegend } from '../Legend/types';
-
-export type Center = [number, number];
 
 // To render data layers on the map
 export type PoiMapData = Partial<{
@@ -24,7 +27,7 @@ export interface PoiMapOptions {
      * Also set the position of the map when rendering.
      */
     bbox?: BBox;
-    center?: Center;
+    center?: LngLatLike;
     zoom?: number;
     // Aspect ratio used to draw the map. The map will take he width available to it, and decide its height based on that ratio.
     aspectRatio?: number;
@@ -90,3 +93,5 @@ export type GeoPoint = {
 };
 
 export type PopupsConfiguration = { [key: string]: PopupLayer };
+
+export type CenterZoomOptions = { zoom?: number; center?: LngLatLike };

--- a/packages/visualizations/src/components/MapPoi/types.ts
+++ b/packages/visualizations/src/components/MapPoi/types.ts
@@ -1,7 +1,10 @@
 import type { CircleLayerSpecification, StyleSpecification, GeoJSONFeature } from 'maplibre-gl';
 import type { BBox, GeoJsonProperties } from 'geojson';
+
 import type { Color, Source } from '../types';
 import type { CategoryLegend } from '../Legend/types';
+
+export type Center = [number, number];
 
 // To render data layers on the map
 export type PoiMapData = Partial<{
@@ -21,6 +24,8 @@ export interface PoiMapOptions {
      * Also set the position of the map when rendering.
      */
     bbox?: BBox;
+    center?: Center;
+    zoom?: number;
     // Aspect ratio used to draw the map. The map will take he width available to it, and decide its height based on that ratio.
     aspectRatio?: number;
     // Is the map interactive for the user (zoom, move, tooltips...)

--- a/packages/visualizations/src/components/MapPoi/utils.ts
+++ b/packages/visualizations/src/components/MapPoi/utils.ts
@@ -7,7 +7,13 @@ import type {
 
 import type { Color } from '../types';
 
-import type { Layer, PoiMapData, PoiMapOptions, PopupsConfiguration } from './types';
+import type {
+    CenterZoomOptions,
+    Layer,
+    PoiMapData,
+    PoiMapOptions,
+    PopupsConfiguration,
+} from './types';
 import { DEFAULT_DARK_GREY, DEFAULT_BASEMAP_STYLE, DEFAULT_ASPECT_RATIO } from './constants';
 
 export const getMapStyle = (style: PoiMapOptions['style']): MapOptions['style'] => {
@@ -116,3 +122,17 @@ export const getMapOptions = (options: PoiMapOptions) => {
         sourceLink,
     };
 };
+
+/**
+ * Generates a valid CenterZoomOptions object by combining optional zoom and center properties.
+ *
+ * @param {CenterZoomOptions} options - An object with optional zoom and center properties.
+ * @returns A CenterZoomOptions object with valid zoom and center properties is defined.
+ */
+export const getCenterZoomOptions: (options: CenterZoomOptions) => CenterZoomOptions = ({
+    zoom,
+    center,
+}) => ({
+    ...(center ? { center } : null),
+    ...(Number.isInteger(zoom) ? { zoom } : null),
+});

--- a/packages/visualizations/src/components/MapPoi/utils.ts
+++ b/packages/visualizations/src/components/MapPoi/utils.ts
@@ -99,6 +99,8 @@ export const getMapOptions = (options: PoiMapOptions) => {
     const {
         aspectRatio = DEFAULT_ASPECT_RATIO,
         bbox = DEFAULT_BBOX,
+        zoom,
+        center,
         interactive = true,
         title,
         subtitle,
@@ -109,6 +111,8 @@ export const getMapOptions = (options: PoiMapOptions) => {
     return {
         aspectRatio,
         bbox,
+        zoom,
+        center,
         interactive,
         title,
         subtitle,

--- a/packages/visualizations/src/components/MapPoi/utils.ts
+++ b/packages/visualizations/src/components/MapPoi/utils.ts
@@ -8,12 +8,7 @@ import type {
 import type { Color } from '../types';
 
 import type { Layer, PoiMapData, PoiMapOptions, PopupsConfiguration } from './types';
-import {
-    DEFAULT_DARK_GREY,
-    DEFAULT_BASEMAP_STYLE,
-    DEFAULT_ASPECT_RATIO,
-    DEFAULT_BBOX,
-} from './constants';
+import { DEFAULT_DARK_GREY, DEFAULT_BASEMAP_STYLE, DEFAULT_ASPECT_RATIO } from './constants';
 
 export const getMapStyle = (style: PoiMapOptions['style']): MapOptions['style'] => {
     if (!style) return DEFAULT_BASEMAP_STYLE;
@@ -98,7 +93,7 @@ export const getPopupsConfiguration = (layers?: Layer[]): PopupsConfiguration =>
 export const getMapOptions = (options: PoiMapOptions) => {
     const {
         aspectRatio = DEFAULT_ASPECT_RATIO,
-        bbox = DEFAULT_BBOX,
+        bbox,
         zoom,
         center,
         interactive = true,

--- a/packages/visualizations/src/stores/createDeepEqual.ts
+++ b/packages/visualizations/src/stores/createDeepEqual.ts
@@ -1,0 +1,29 @@
+import { writable, get } from 'svelte/store';
+
+/**
+ * Creates a Svelte writable store that compares values deeply before updating.
+ *
+ * @param initialValue - The initial value for the store.
+ * @returns An object containing the subscribe and set methods.
+ */
+const createDeepEqual = <V>(initialValue: V | undefined) => {
+    const value = writable<V | undefined>(initialValue);
+
+    return {
+        /**
+         * Subscribes to changes in the store's value.
+         */
+        subscribe: value.subscribe,
+        /**
+         * Sets the new value for the store if it differs from the current value
+         * by performing a deep comparison.
+         */
+        set: (newValue: V | undefined) => {
+            if (JSON.stringify(newValue) !== JSON.stringify(get(value))) {
+                value.set(newValue);
+            }
+        },
+    };
+};
+
+export default createDeepEqual;


### PR DESCRIPTION
## Summary

The goal for this PR is to add `zoom`and `center`in the options prop

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-43528](https://app.shortcut.com/opendatasoft/story/43528).

### Changes

Fix a behavior where the map bbox was updated when a change in `options`. Did the same thing for the center prop.In `Map.svelte` the `bbox` and `center` given to `mapRender` change only their value change not their reference. 

Maybe we can factorize this code into something like` const freshCenter = useFreshValue(center, comparaisonCallback)`

#### Breaking Changes

none

### Changelog

/

## Open discussion

/

## To be tested

/

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
