### PR TITLE
[FIX][POI Map] Clicked feature is always visible when sidebar popup is open

### DIFF
--- a/packages/visualizations/src/components/MapPoi/constants.ts
+++ b/packages/visualizations/src/components/MapPoi/constants.ts
@@ -12,8 +12,10 @@ export const DEFAULT_ASPECT_RATIO = 1;
 
 export const DEFAULT_DARK_GREY: Color = '#515457';
 
+export const POPUP_WIDTH = 300;
+
 export const POPUP_OPTIONS: PopupOptions = {
     className: 'poi-map__popup',
     closeButton: false,
-    maxWidth: '300px',
+    maxWidth: `${POPUP_WIDTH}px`,
 };


### PR DESCRIPTION
## Summary

The goal for this PR is to add a simple rule to make the clicked feature still visible when the sidebar popup is open. 

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-43611](https://app.shortcut.com/opendatasoft/story/43611).

### Changes

If the popup is of type 'sidebar', the map will be centred on the element clicked, with a left margin of 300px.
As you can see in the video, we don't return to the initial center before clicking. 

IMO, this is still a good improvement and as the sidebar is probably going to be completely redesigned, it may not be worth spending any more time on it to try to going back to the original center.

https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/22045473-425b-453c-96a9-e400721eab3f


#### Breaking Changes
/

### Changelog

/

## Open discussion

/

## To be tested

/

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
