### PR TITLE
fix(api-client): Fix Facet types to match API v2.1

### DIFF
--- a/packages/api-client/src/client/types.ts
+++ b/packages/api-client/src/client/types.ts
@@ -3,8 +3,14 @@
 export interface Facet {
     name: string;
     count: number;
-    path?: string;
+    value: string;
+    state: 'displayed' | 'refined' | 'excluded';
     facets?: Facet[];
+}
+
+export interface FacetRoot {
+    name: string;
+    facets: Facet[];
 }
 
 export interface Link {
@@ -51,7 +57,7 @@ export interface ApiDatasets {
 
 export interface ApiFacets {
     links: Link[];
-    facets: Facet[];
+    facets: FacetRoot[];
 }
 
 export interface ApiQuery<T> {


### PR DESCRIPTION
## Summary

The goal for this PR is to fix a mismatch between `Facet` type and the reality of what the API provides.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-44362](https://app.shortcut.com/opendatasoft/story/44362/api-client-facet-typing-doesn-t-match-api-structure).

### Changes

The changes are made to match the current structure of both facets endpoint in the API.


### Changelog

`Facet` types has been fixed to properly match Opendatasoft's API responses.

## Open discussion
I added `state` as a very simple type without an enum. I don't think it's worth adding an enum here. 


## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
