### PR TITLE
Reset bbox to initial state when interactivity is disabled

### DIFF
--- a/packages/visualizations/src/components/MapPoi/Map.ts
+++ b/packages/visualizations/src/components/MapPoi/Map.ts
@@ -318,7 +318,10 @@ export default class MapPOI {
         this.queue((map) => this.setPopup(map));
     }
 
-    toggleInteractivity(interaction: 'enable' | 'disable') {
+    toggleInteractivity(
+        interaction: 'enable' | 'disable',
+        { onDisable, onEnable }: { onDisable?: () => void; onEnable?: () => void }
+    ) {
         this.queue((map) => {
             map.boxZoom[interaction]();
             map.doubleClickZoom[interaction]();
@@ -335,12 +338,14 @@ export default class MapPOI {
             const hasControl = map.hasControl(this.navigationControl);
 
             if (interaction === 'disable') {
+                onDisable?.();
                 this.popup.remove();
                 if (hasControl) {
                     map.removeControl(this.navigationControl);
                 }
             }
             if (interaction === 'enable') {
+                onEnable?.();
                 if (!hasControl) {
                     map.addControl(this.navigationControl, 'top-right');
                 }

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -42,7 +42,11 @@
     let container: HTMLElement;
     const map = new Map();
 
-    $: map.toggleInteractivity(interactive ? 'enable' : 'disable');
+    const onDisable = () => {
+        map.setBbox(bbox);
+    };
+
+    $: map.toggleInteractivity(interactive ? 'enable' : 'disable', { onDisable });
     $: map.setBbox(bbox);
     $: map.setMinZoom(minZoom);
     $: map.setMaxZoom(maxZoom);


### PR DESCRIPTION
## Summary

The goal for this PR is to reset the bbox to its initial state when disabling map interactivity. 

https://github.com/opendatasoft/ods-dataviz-sdk/assets/84501475/941cfa8d-7bc8-4d85-9b05-b7783d56c7ed


(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-44552](https://app.shortcut.com/opendatasoft/story/44552/studio-poi-maps-bbox-doesn-t-reset-when-the-block-is-deselected).

### Changes

In MapPOI class we memoize the `bbox` passed to `setBbox` to be able to reset the bounds to the initial state in `toggleInteractivity`.

#### Breaking Changes

Should be none should only fit map to initial bounds when interactivity is disabled.

### Changelog

We fixed a bug in POI maps where the bbox was not reinitialized to initial bounds after disabling interactivity.

## Open discussion

I had the choice between storing the initial `bbox` in the class `MapPOI` or passing it as an argument in the `toggleVisibilityFunction`. I decided to choose the first option as it seemed more clean for me and this is also the approach in the choropleths, we store the `bbox` passed from config, but the mechanism seems maybe more natural in a svelte component. In choropleth we also need a `currentBbox` as we sometimes switch bboxes when using navigation buttons on the map. I'm open for discussion if you see or think of a better option !

## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
