### PR TITLE
fix: destructure style options

### DIFF
--- a/packages/visualizations/src/components/MapPoi/Map.svelte
+++ b/packages/visualizations/src/components/MapPoi/Map.svelte
@@ -17,7 +17,8 @@
     export let data: Async<PoiMapData>;
     export let options: PoiMapOptions;
 
-    $: style = getMapStyle(options.style);
+    $: ({ style: styleOptions } = options);
+    $: style = getMapStyle(styleOptions);
     $: sources = getMapSources(data.value?.sources);
     $: layers = getMapLayers(data.value?.layers);
     $: popupsConfiguration = getPopupsConfiguration(data.value?.layers);


### PR DESCRIPTION
## Summary

The goal for this PR is to destructure the style options, so that the reactive call is not triggered if `options` but not `options.style` changes.

Admittedly, `{#key …` and `$: …` seems to work differently on that matter.

## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
