### PR TITLE
[SC-44672][FEAT] Add new legend symbol: `Image`

### DIFF
--- a/packages/visualizations-react/stories/Poi/PoiMap.stories.tsx
+++ b/packages/visualizations-react/stories/Poi/PoiMap.stories.tsx
@@ -59,35 +59,50 @@ const citiesColorMatch = {
 
 const bbox: BBox = [-6.855469, 41.343825, 11.645508, 51.37178];
 
+const legendCitiesItems = [
+    {
+        label: 'Paris',
+        color: citiesColorMatch.colors.Paris,
+        borderColor: citiesColorMatch.borderColors.Paris,
+        variant: CATEGORY_ITEM_VARIANT.Circle,
+    },
+    {
+        label: 'Nantes',
+        color: citiesColorMatch.colors.Nantes,
+        borderColor: citiesColorMatch.borderColors.Nantes,
+        variant: CATEGORY_ITEM_VARIANT.Circle,
+    },
+    {
+        label: 'Bordeaux',
+        color: citiesColorMatch.colors.Bordeaux,
+        borderColor: citiesColorMatch.borderColors.Bordeaux,
+        variant: CATEGORY_ITEM_VARIANT.Circle,
+    },
+    {
+        label: 'Marseille',
+        color: citiesColorMatch.colors.Marseille,
+        borderColor: citiesColorMatch.borderColors.Marseille,
+        variant: CATEGORY_ITEM_VARIANT.Circle,
+    },
+];
+
+const legendbattleItems = [
+    {
+        variant: CATEGORY_ITEM_VARIANT.Image,
+        label: 'Battle of Verdun',
+        src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Battle_icon_gladii_red.svg/14px-Battle_icon_gladii_red.svg.png',
+    },
+    {
+        variant: CATEGORY_ITEM_VARIANT.Image,
+        label: 'Battle of the Somme',
+        src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/50/Big_battle_symbol.svg/14px-Big_battle_symbol.svg.png',
+    },
+];
+
 const legend = {
     type: 'category' as const,
-    title: 'French cities',
-    items: [
-        {
-            label: 'Paris',
-            color: citiesColorMatch.colors.Paris,
-            borderColor: citiesColorMatch.borderColors.Paris,
-            variant: CATEGORY_ITEM_VARIANT.Circle,
-        },
-        {
-            label: 'Nantes',
-            color: citiesColorMatch.colors.Nantes,
-            borderColor: citiesColorMatch.borderColors.Nantes,
-            variant: CATEGORY_ITEM_VARIANT.Circle,
-        },
-        {
-            label: 'Bordeaux',
-            color: citiesColorMatch.colors.Bordeaux,
-            borderColor: citiesColorMatch.borderColors.Bordeaux,
-            variant: CATEGORY_ITEM_VARIANT.Circle,
-        },
-        {
-            label: 'Marseille',
-            color: citiesColorMatch.colors.Marseille,
-            borderColor: citiesColorMatch.borderColors.Marseille,
-            variant: CATEGORY_ITEM_VARIANT.Circle,
-        },
-    ],
+    title: 'French cities and famous battles',
+    items: [...legendCitiesItems, ...legendbattleItems],
     align: 'start' as const,
 };
 

--- a/packages/visualizations/src/components/Legend/CategoryLegend/Item/CategoryLegendItemSymbol.svelte
+++ b/packages/visualizations/src/components/Legend/CategoryLegend/Item/CategoryLegendItemSymbol.svelte
@@ -2,6 +2,7 @@
     import BoxSymbol from '../Symbols/BoxSymbol.svelte';
     import LineSymbol from '../Symbols/LineSymbol.svelte';
     import CircleSymbol from '../Symbols/CircleSymbol.svelte';
+    import ImageSymbol from '../Symbols/ImageSymbol.svelte';
     import type { CategoryItem } from '../../types';
     import { CATEGORY_ITEM_VARIANT } from '../../types';
 
@@ -12,6 +13,8 @@
     <CircleSymbol {item} />
 {:else if item.variant === CATEGORY_ITEM_VARIANT.Box}
     <BoxSymbol {item} />
-{:else}
+{:else if item.variant === CATEGORY_ITEM_VARIANT.Line}
     <LineSymbol {item} />
+{:else if item.variant === CATEGORY_ITEM_VARIANT.Image}
+    <ImageSymbol {item} />
 {/if}

--- a/packages/visualizations/src/components/Legend/CategoryLegend/Symbols/ImageSymbol.svelte
+++ b/packages/visualizations/src/components/Legend/CategoryLegend/Symbols/ImageSymbol.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import type { ImageCategoryItem } from '../../types';
+
+    export let item: ImageCategoryItem;
+</script>
+
+<!-- svelte-ignore a11y-missing-attribute -->
+<img src={item.src} />
+
+<style>
+    img {
+        width: 16px;
+        margin-right: 6px;
+        object-fit: contain;
+    }
+</style>

--- a/packages/visualizations/src/components/Legend/types.ts
+++ b/packages/visualizations/src/components/Legend/types.ts
@@ -29,6 +29,7 @@ export const CATEGORY_ITEM_VARIANT = {
     Circle: 'circle',
     Line: 'line',
     Box: 'box',
+    Image: 'image',
 } as const;
 
 type BaseCategoryItem = {
@@ -56,7 +57,16 @@ export type LineCategoryItem = BaseCategoryItem & {
     dashed?: boolean;
 };
 
-export type CategoryItem = CircleCategoryItem | BoxCategoryItem | LineCategoryItem;
+export type ImageCategoryItem = BaseCategoryItem & {
+    variant: typeof CATEGORY_ITEM_VARIANT.Image;
+    src: string;
+};
+
+export type CategoryItem =
+    | CircleCategoryItem
+    | BoxCategoryItem
+    | LineCategoryItem
+    | ImageCategoryItem;
 
 export type CategoryLegend = {
     type: 'category';


### PR DESCRIPTION
## Summary

The goal for this PR is to add a new legend symbol in the legend.

Render an image as a legend item by providing an URL

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-44672](https://app.shortcut.com/opendatasoft/story/44672).

![image](https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/eb8f7342-09ae-4fc3-8746-6659996b810a)

### Changes

- A new legend item symbol: ImageSymbol
- Update POI map stories

#### Breaking Changes

_describe the changes that are not backward compatible_

## Open discussion

Should we add the alt property ?  
## To be tested

Try to load large images to break the legend layout

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
