### PR TITLE
[FEATURE][SC-44895][POI MAP] Popup improvements

### DIFF
--- a/packages/visualizations-react/stories/Poi/sources.ts
+++ b/packages/visualizations-react/stories/Poi/sources.ts
@@ -15,7 +15,8 @@ const sources : PoiMapData["sources"] = {
                         coordinates: [2.357573,48.837904],
                     },
                     properties: {
-                        key: 'Paris'
+                        key: 'Paris',
+                        description: 'Officia deserunt commodo enim ea ad veniam enim consectetur aliquip adipisicing duis. Exercitation aute velit pariatur est et ea qui veniam ad duis quis ad aliquip. Ipsum exercitation dolor tempor deserunt sunt amet laborum tempor excepteur est sunt ea quis.'
                     },
                 },
                 {
@@ -26,7 +27,8 @@ const sources : PoiMapData["sources"] = {
                         coordinates: [-0.563328,44.838245],
                     },
                     properties: {
-                        key: 'Bordeaux'
+                        key: 'Bordeaux',
+                        description: 'Pariatur duis mollit sit id ullamco ea non ad dolore voluptate nostrud deserunt fugiat proident. Sunt dolor qui consectetur exercitation mollit proident Lorem laborum cillum sit Lorem id eiusmod. Lorem culpa tempor aliqua aliquip reprehenderit. Aute officia reprehenderit aute pariatur incididunt nostrud exercitation voluptate id est ex. Qui eiusmod est enim est ipsum elit laboris.'
                     },
                 },
                 {
@@ -37,7 +39,8 @@ const sources : PoiMapData["sources"] = {
                         coordinates: [-1.552924,47.214847],
                     },
                     properties: {
-                        key: 'Nantes'
+                        key: 'Nantes',
+                        description: "Irure incididunt deserunt officia eiusmod occaecat duis nostrud sint excepteur. Id non voluptate non proident sunt sit nisi eiusmod sit excepteur duis cillum adipisicing. Nostrud officia ad tempor quis commodo aute elit tempor reprehenderit esse est aute fugiat reprehenderit. Aliquip eu occaecat Lorem cupidatat labore consequat. Culpa commodo sunt proident exercitation. Enim voluptate minim veniam enim nulla aute dolor magna est elit aliqua. Ex occaecat fugiat laboris do do dolor nostrud cupidatat."
                     },
                 },
                 {
@@ -48,7 +51,8 @@ const sources : PoiMapData["sources"] = {
                         coordinates: [5.360529,43.303114],
                     },
                     properties: {
-                        key: 'Marseille'
+                        key: 'Marseille',
+                        description: "Dolore nisi non id labore. Ea deserunt irure nisi nisi deserunt anim nisi et. Culpa sint mollit deserunt ea eiusmod laborum nostrud."
                     },
                 },
             ],
@@ -65,7 +69,7 @@ const sources : PoiMapData["sources"] = {
                     properties: {
                         name: "Battle of Verdun",
                         date: "1916",
-                        description: "The Battle of Verdun was fought from 21 February to 18 December 1916 on the Western Front in France. The battle was the longest of the First World War and took place on the hills north of Verdun-sur-Meuse."
+                        description: "The Battle of Verdun was fought from 21 February to 18 December 1916 on the Western Front in France. The battle was the longest of the First World War and took place on the hills north of Verdun-sur-Meuse. Nisi magna dolor ullamco Lorem culpa ea tempor exercitation dolor ex cupidatat esse voluptate ea. Incididunt consectetur ut officia eiusmod voluptate commodo adipisicing tempor eiusmod esse nulla veniam ut. Aute ipsum eiusmod culpa dolore ea aliquip nulla consectetur reprehenderit in mollit nostrud. Elit commodo non est voluptate pariatur. Exercitation reprehenderit pariatur dolore aute elit ea dolor commodo cillum. Est dolore ut elit in. Ullamco est laborum aute labore. Cillum incididunt laboris do eiusmod fugiat enim veniam aliquip duis incididunt laboris anim nostrud. Laborum mollit esse magna fugiat fugiat fugiat aliquip." 
                     },
                     geometry: {
                         type: "Point",

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -245,6 +245,7 @@
             </div>
         {/if}
         <figure class="chart legend--{legendPosition}">
+            <!-- svelte-ignore a11y-no-interactive-element-to-noninteractive-role -->
             <canvas
                 role="img"
                 use:chartJs={chartConfig}

--- a/packages/visualizations/src/components/Legend/CategoryLegend/Item/CategoryLegendItem.svelte
+++ b/packages/visualizations/src/components/Legend/CategoryLegend/Item/CategoryLegendItem.svelte
@@ -8,14 +8,23 @@
     export let toggleSerie: (index: number) => void;
     export let refined: boolean;
 
+    const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key !== 'Enter' || !item.onClick) return;
+        toggleSerie(itemIndex);
+        item.onClick(itemIndex);
+    };
+
     $: stringLabel =
         item.label &&
         (typeof item.label === 'string' ? item.label : item?.label?.text?.(itemIndex));
 </script>
 
 <div
+    role="button"
+    tabindex={item.onClick ? 0 : -1}
     class:refined
     style="--cursor-style: {item.onClick ? 'pointer' : 'default'};"
+    on:keydown={onKeyDown}
     on:click={() => {
         if (item.onClick) {
             toggleSerie(itemIndex);

--- a/packages/visualizations/src/components/MapPoi/Map.svelte
+++ b/packages/visualizations/src/components/MapPoi/Map.svelte
@@ -9,7 +9,7 @@
         getMapStyle,
         getMapSources,
         getMapLayers,
-        getPopupsConfiguration,
+        getPopupConfigurationByLayers,
         getMapOptions,
     } from './utils';
     import type { PoiMapData, PoiMapOptions } from './types';
@@ -21,7 +21,7 @@
     $: style = getMapStyle(styleOptions);
     $: sources = getMapSources(data.value?.sources);
     $: layers = getMapLayers(data.value?.layers);
-    $: popupsConfiguration = getPopupsConfiguration(data.value?.layers);
+    $: popupConfigurationByLayers = getPopupConfigurationByLayers(data.value?.layers);
 
     $: ({
         bbox: _bbox,
@@ -53,7 +53,7 @@
             {style}
             {sources}
             {layers}
-            {popupsConfiguration}
+            {popupConfigurationByLayers}
             bbox={$bbox}
             center={$center}
             {zoom}

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -163,6 +163,7 @@
 
     .map-card :global(.poi-map__popup.poi-map__popup--as-tooltip) {
         width: 300px !important;
+        max-height: 50%;
     }
 
     /* --- POPUP TIP ---  */
@@ -180,6 +181,7 @@
         border-radius: 6px;
         max-height: 100%;
         overflow-y: auto;
+        overflow-x: hidden;
         box-sizing: border-box;
         box-shadow: 0 6px 13px 0 rgba(0, 0, 0, 0.26);
     }

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -17,7 +17,7 @@
 
     import Map from './Map';
     import { getCenterZoomOptions } from './utils';
-    import type { PopupsConfiguration, PoiMapOptions } from './types';
+    import type { PopupConfigurationByLayers, PoiMapOptions } from './types';
 
     // Base style, sources and layers
     export let style: MapOptions['style'];
@@ -45,7 +45,7 @@
     // Used in front of console and error messages to debug multiple maps on a same page
     const mapId = Math.floor(Math.random() * 1000);
 
-    export let popupsConfiguration: PopupsConfiguration;
+    export let popupConfigurationByLayers: PopupConfigurationByLayers;
 
     let container: HTMLElement;
     const map = new Map();
@@ -59,7 +59,7 @@
     $: map.setMinZoom(minZoom);
     $: map.setMaxZoom(maxZoom);
     $: map.setSourcesAndLayers(sources, layers);
-    $: map.setPopupsConfiguration(popupsConfiguration);
+    $: map.setpopupConfigurationByLayers(popupConfigurationByLayers);
     $: map.jumpTo(getCenterZoomOptions({ zoom, center }));
     $: map.loadImages(images);
     $: cssVarStyles = `--aspect-ratio:${aspectRatio};`;
@@ -134,31 +134,87 @@
     figcaption h3 {
         margin: 0;
     }
+
     /* To add classes programmatically in svelte we will use a global selector. We place it inside a local selector to obtain some encapsulation and avoid side effects */
+
+    /* --- POPUP ---  */
     .map-card :global(.poi-map__popup) {
         /* To be above map controls (z-index: 2)*/
         z-index: 3;
-        /* 26px is for its padding */
-        max-height: calc(100% - 26px);
         height: auto;
-        overflow-y: auto;
+        max-height: 100%;
+        box-sizing: border-box;
+        max-width: none !important;
+    }
+    .map-card :global(.poi-map__popup.poi-map__popup--as-sidebar),
+    .map-card :global(.poi-map__popup.poi-map__popup--as-modal) {
+        flex-direction: column;
+        transform: translate(0px, 0px) !important;
+        padding: 13px 13px 0px 13px;
+    }
+
+    .map-card :global(.poi-map__popup.poi-map__popup--as-modal) {
+        width: 100% !important;
     }
     .map-card :global(.poi-map__popup.poi-map__popup--as-sidebar) {
-        /* TO DO: add common stylesheet */
-        transform: translate(13px, 13px) !important;
+        /* 300px for content and 26px for padding */
+        width: calc(300px + 26px) !important;
     }
-    .map-card :global(.poi-map__popup.poi-map__popup--as-sidebar > .maplibregl-popup-tip) {
+
+    .map-card :global(.poi-map__popup.poi-map__popup--as-tooltip) {
+        width: 300px !important;
+    }
+
+    /* --- POPUP TIP ---  */
+    .map-card :global(.poi-map__popup.poi-map__popup--as-sidebar > .maplibregl-popup-tip),
+    :global(.poi-map__popup.poi-map__popup--as-modal > .maplibregl-popup-tip) {
         display: none;
     }
+
+    /* --- POPUP CONTENT ---  */
     .map-card :global(.poi-map__popup > .maplibregl-popup-content) {
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
         padding: 13px;
         border-radius: 6px;
+        max-height: 100%;
+        overflow-y: auto;
+        box-sizing: border-box;
         box-shadow: 0 6px 13px 0 rgba(0, 0, 0, 0.26);
     }
     /* Add a more opacity and blur effect on map when cooperative gesture is shown */
     .map-card :global(.maplibregl-cooperative-gesture-screen) {
         background: rgba(0, 0, 0, 0.6);
         backdrop-filter: blur(2px);
+    }
+
+    /* --- POPUP CLOSE BUTTON ---  */
+    .map-card :global(.maplibregl-popup-close-button) {
+        font-size: 16px;
+        padding: 0;
+        width: 24px;
+        height: 24px;
+        margin-bottom: 13px;
+        position: relative;
+        order: -1;
+        flex-shrink: 0;
+        left: calc(100% - 26px);
+    }
+    .map-card :global(.maplibregl-popup-close-button:hover) {
+        background-color: transparent;
+    }
+    /* Hide close button when content is loading or when its display is as a tooltip */
+    .map-card :global(.poi-map__popup--loading .maplibregl-popup-close-button),
+    .map-card :global(.poi-map__popup--as-tooltip .maplibregl-popup-close-button) {
+        display: none;
+    }
+
+    /* --- CONTROLS --- */
+    .map-card :global(.maplibregl-ctrl.maplibregl-ctrl-group) {
+        margin-top: 13px;
+        margin-right: 13px;
+        box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.26);
     }
     .main {
         aspect-ratio: var(--aspect-ratio);

--- a/packages/visualizations/src/components/MapPoi/constants.ts
+++ b/packages/visualizations/src/components/MapPoi/constants.ts
@@ -1,5 +1,6 @@
 import type { PopupOptions, StyleSpecification } from 'maplibre-gl';
 import type { Color } from '../types';
+import { POPUP_DISPLAY, PopupDisplayTypes } from './types';
 
 export const DEFAULT_BASEMAP_STYLE: StyleSpecification = {
     version: 8,
@@ -14,8 +15,17 @@ export const DEFAULT_DARK_GREY: Color = '#515457';
 
 export const POPUP_WIDTH = 300;
 
+// Update styles in ./MapRender.svelte if this classname changes
+export const POPUP_CLASSNAME = 'poi-map__popup';
+
+export const POPUP_DISPLAY_CLASSNAME_MODIFIER: Record<PopupDisplayTypes, string> = {
+    [POPUP_DISPLAY.tooltip]: `${POPUP_CLASSNAME}--as-tooltip`,
+    [POPUP_DISPLAY.sidebar]: `${POPUP_CLASSNAME}--as-sidebar`,
+    [POPUP_DISPLAY.modal]: `${POPUP_CLASSNAME}--as-modal`,
+};
+
 export const POPUP_OPTIONS: PopupOptions = {
-    className: 'poi-map__popup',
-    closeButton: false,
+    className: POPUP_CLASSNAME,
+    closeButton: true,
     closeOnClick: false,
 };

--- a/packages/visualizations/src/components/MapPoi/types.ts
+++ b/packages/visualizations/src/components/MapPoi/types.ts
@@ -109,16 +109,20 @@ export type SymbolLayer = BaseLayer & {
 
 export type Layer = CircleLayer | SymbolLayer;
 
-export enum PopupDisplayTypes {
-    Tooltip = 'tooltip',
-    Sidebar = 'sidebar',
-}
+export const POPUP_DISPLAY = {
+    tooltip: 'tooltip',
+    sidebar: 'sidebar',
+    modal: 'modal',
+} as const;
+
+export type PopupDisplayTypes = keyof typeof POPUP_DISPLAY;
 
 export type PopupLayer = {
     /**
      * Control where to display the popup
      * - `sidebar`: As a side element (on the left)
      * - `tooltip`: Above the feature that has been clicked
+     * - `modal`: As a modal (takes all width)
      */
     display: PopupDisplayTypes;
     getContent: (id?: GeoJSONFeature['id'], properties?: GeoJsonProperties) => Promise<string>;
@@ -129,7 +133,7 @@ export type GeoPoint = {
     lat: number;
     lon: number;
 };
-
-export type PopupsConfiguration = { [key: string]: PopupLayer };
+/** A configuration map for popups where keys are layer ids and values are PopupLayer object. */
+export type PopupConfigurationByLayers = { [key: string]: PopupLayer };
 
 export type CenterZoomOptions = { zoom?: number; center?: LngLatLike };

--- a/packages/visualizations/src/components/MapPoi/utils.ts
+++ b/packages/visualizations/src/components/MapPoi/utils.ts
@@ -17,7 +17,7 @@ import type {
     Layer,
     PoiMapData,
     PoiMapOptions,
-    PopupsConfiguration,
+    PopupConfigurationByLayers,
     SymbolLayer,
 } from './types';
 import { DEFAULT_DARK_GREY, DEFAULT_BASEMAP_STYLE, DEFAULT_ASPECT_RATIO } from './constants';
@@ -144,14 +144,14 @@ export const getMapLayers = (layers?: Layer[]): LayerSpecification[] => {
     });
 };
 
-export const getPopupsConfiguration = (layers?: Layer[]): PopupsConfiguration => {
-    const configuration: PopupsConfiguration = {};
+export const getPopupConfigurationByLayers = (layers?: Layer[]): PopupConfigurationByLayers => {
+    const configurationByLayers: PopupConfigurationByLayers = {};
     layers?.forEach(({ id, popup }) => {
         if (popup) {
-            configuration[id] = popup;
+            configurationByLayers[id] = popup;
         }
     });
-    return configuration;
+    return configurationByLayers;
 };
 
 export const getMapOptions = (options: PoiMapOptions) => {


### PR DESCRIPTION
## Summary

~~The goal for this PR is to improve popup display on small screen.~~
~~The popup position is forced (take full width) when the map width is below 600px).~~
~~Also add a close icon button on popup (only for sidebar popup or when map size is below 600px)~~

The goal for this PR is to add a new popup display option: Modal
The popup takes the full width available. 
Popup height is based on its content with a `max-height` of `100%`

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-44895](https://app.shortcut.com/opendatasoft/story/44895). Can be tested with https://github.com/opendatasoft/platform/pull/11413
![Screenshot 2023-11-27 at 13 36 18](https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/6c32c218-60d5-4104-9f7d-16fbda832c1c)


### Changes

- Update Svelte to the last v3 version. ~~Need it to use CSS container queries. Support starts from v3.58.0~~
- Improve accessibility of legend items



## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
