### PR TITLE
feat: add cooperative gestures for maps

### DIFF
--- a/packages/visualizations-react/stories/Map/StudioChoropleth.stories.tsx
+++ b/packages/visualizations-react/stories/Map/StudioChoropleth.stories.tsx
@@ -398,3 +398,31 @@ const StudioChoroplethPreventWorldCopiesArgs: Props<DataFrame, ChoroplethGeoJson
     },
 };
 StudioChoroplethPreventWorldCopies.args = StudioChoroplethPreventWorldCopiesArgs;
+
+export const StudioChoroplethCooperativeGestures = Template.bind({});
+const StudioChoroplethCooperativeGesturesArgs: Props<DataFrame, ChoroplethGeoJsonOptions> = {
+    data: {
+        loading: false,
+        value: [
+            { x: 'France', y: 60 },
+            { x: 'Île de France', y: 35 },
+            { x: 'Corsica', y: 95 },
+        ],
+    },
+    options: {
+        shapes,
+        emptyValueColor: 'red',
+        tooltip: {
+            formatter: defaultLabelCallback,
+        },
+        aspectRatio: 1,
+        attribution: 'Testing attribution',
+        description: 'Accessible description',
+        cooperativeGestures: {
+            windowsHelpText: 'Use Ctrl + scroll to zoom the map',
+            macHelpText: 'Use ⌘ + scroll to zoom the map',
+            mobileHelpText: 'Use two fingers to move the map',
+        },
+    },
+};
+StudioChoroplethCooperativeGestures.args = StudioChoroplethCooperativeGesturesArgs;

--- a/packages/visualizations-react/stories/Map/StudioChoroplethVector.stories.tsx
+++ b/packages/visualizations-react/stories/Map/StudioChoroplethVector.stories.tsx
@@ -65,6 +65,7 @@ const StudioChoroplethVectorGradientArgs: Props<DataFrame, ChoroplethVectorTiles
         value: dataReg,
     },
     options: {
+        bbox: [-17.529298, 38.79776, 23.889159, 52.836618],
         shapesTiles,
         colorScale: {
             type: ColorScaleTypes.Gradient,
@@ -310,6 +311,42 @@ const StudioChoroplethNavigationMapButtonsArgs: Props<DataFrame, ChoroplethVecto
     },
 };
 StudioChoroplethNavigationMapButtons.args = StudioChoroplethNavigationMapButtonsArgs;
+
+export const StudioChoroplethVectorCooperativeGestures = Template.bind({});
+const StudioChoroplethVectorCooperativeGesturesArgs: Props<DataFrame, ChoroplethVectorTilesOptions> = {
+    data: {
+        loading: false,
+        value: dataReg,
+    },
+    options: {
+        shapesTiles,
+        colorScale: {
+            type: ColorScaleTypes.Gradient,
+            colors: {
+                start: '#bcf5f9',
+                end: '#0229bf',
+            },
+        },
+        legend: {
+            title: 'I Am Legend',
+        },
+        aspectRatio: 1,
+        activeShapes: ['11', '93'],
+        emptyValueColor: 'red',
+        tooltip: {
+            formatter: defaultLabelCallback,
+        },
+        bbox: [-17.529298, 38.79776, 23.889159, 52.836618],
+        navigationMaps: [...makeMiniMaps(15),],
+        sourceLink: defaultSource,
+        cooperativeGestures: {
+            windowsHelpText: 'Use Ctrl + scroll to zoom the map',
+            macHelpText: 'Use ⌘ + scroll to zoom the map',
+            mobileHelpText: 'Use two fingers to move the map',
+        },
+    },
+};
+StudioChoroplethVectorCooperativeGestures.args = StudioChoroplethVectorCooperativeGesturesArgs;
 
 /* The next story was used for the demo, but its too big for chromatic, keeping it hear for future ref on loading/wathever */
 // const LoaderTemplate: ComponentStory<typeof Choropleth> = (args, { loaded: { data } }) => (

--- a/packages/visualizations-react/stories/Poi/PoiMap.stories.tsx
+++ b/packages/visualizations-react/stories/Poi/PoiMap.stories.tsx
@@ -177,7 +177,7 @@ PoiMapLegendCenter.args = PoiMapLegendCenterArgs;
 export const PoiMapMinMaxZooms: ComponentStory<typeof PoiMap> = Template.bind({});
 const PoiMapMinMaxZoomsArgs = {
     data: { value: { layers: [{ ...layer1, colorMatch: citiesColorMatch }, layer2], sources } },
-    options: { 
+    options: {
         ...options,
         legend,
         minZoom: 3,
@@ -185,3 +185,21 @@ const PoiMapMinMaxZoomsArgs = {
     },
 };
 PoiMapMinMaxZooms.args = PoiMapMinMaxZoomsArgs;
+
+/**
+ * STORY: with cooperative gestures
+ */
+export const PoiMapCooperativeGestures: ComponentStory<typeof PoiMap> = Template.bind({});
+const PoiMapCooperativeGesturesArgs = {
+    data: { value: { layers: [{ ...layer1, colorMatch: citiesColorMatch }, layer2], sources } },
+    options: {
+        ...options,
+        legend,
+        cooperativeGestures: {
+            windowsHelpText: 'Use Ctrl + scroll to zoom the map',
+            macHelpText: 'Use ⌘ + scroll to zoom the map',
+            mobileHelpText: 'Use two fingers to move the map',
+        },
+    },
+};
+PoiMapCooperativeGestures.args = PoiMapCooperativeGesturesArgs;

--- a/packages/visualizations/package-lock.json
+++ b/packages/visualizations/package-lock.json
@@ -21,7 +21,7 @@
                 "immutability-helper": "^3.1.1",
                 "lodash": "^4.17.21",
                 "luxon": "^2.5.0",
-                "maplibre-gl": "2.2.0",
+                "maplibre-gl": "2.2.1",
                 "markdown-it": "^12.0.4",
                 "markdown-it-link-attributes": "^3.0.0",
                 "markdown-it-mark": "^3.0.1",
@@ -5120,9 +5120,9 @@
             }
         },
         "node_modules/maplibre-gl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.2.0.tgz",
-            "integrity": "sha512-5LB7ROIxvBADPa4PmU2j+mp0jG5IIbEidCOyZEXVbEriluMJn0hz28vszVb4Cr2IA4YQ9cnERqjHaf33MHIRBQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.2.1.tgz",
+            "integrity": "sha512-5WSzGRwbxcIkZ/DRDI+A3/o69IoLKFN80jtVqiqUuw0y1u24ZwVvqSr2fqLslUa0Yig1Z50w+wWdnER3JNOzPQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "@mapbox/geojson-rewind": "^0.5.2",
@@ -11686,9 +11686,9 @@
             }
         },
         "maplibre-gl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.2.0.tgz",
-            "integrity": "sha512-5LB7ROIxvBADPa4PmU2j+mp0jG5IIbEidCOyZEXVbEriluMJn0hz28vszVb4Cr2IA4YQ9cnERqjHaf33MHIRBQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.2.1.tgz",
+            "integrity": "sha512-5WSzGRwbxcIkZ/DRDI+A3/o69IoLKFN80jtVqiqUuw0y1u24ZwVvqSr2fqLslUa0Yig1Z50w+wWdnER3JNOzPQ==",
             "requires": {
                 "@mapbox/geojson-rewind": "^0.5.2",
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",

--- a/packages/visualizations/package-lock.json
+++ b/packages/visualizations/package-lock.json
@@ -21,7 +21,7 @@
                 "immutability-helper": "^3.1.1",
                 "lodash": "^4.17.21",
                 "luxon": "^2.5.0",
-                "maplibre-gl": "2.1.9",
+                "maplibre-gl": "2.2.0",
                 "markdown-it": "^12.0.4",
                 "markdown-it-link-attributes": "^3.0.0",
                 "markdown-it-mark": "^3.0.1",
@@ -1721,12 +1721,12 @@
             }
         },
         "node_modules/@mapbox/geojson-rewind": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz",
-            "integrity": "sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+            "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
             "dependencies": {
                 "get-stream": "^6.0.1",
-                "minimist": "^1.2.5"
+                "minimist": "^1.2.6"
             },
             "bin": {
                 "geojson-rewind": "geojson-rewind"
@@ -3377,9 +3377,9 @@
             }
         },
         "node_modules/earcut": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-            "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+            "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
         },
         "node_modules/electron-to-chromium": {
             "version": "1.3.846",
@@ -5120,32 +5120,32 @@
             }
         },
         "node_modules/maplibre-gl": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.1.9.tgz",
-            "integrity": "sha512-pnWJmILeZpgA5QSI7K7xFK3yrkyYTd9srw3fCi2Ca52Phm78hsznPwUErEQcZLfxXKn/1h9t8IPdj0TH0NBNbg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.2.0.tgz",
+            "integrity": "sha512-5LB7ROIxvBADPa4PmU2j+mp0jG5IIbEidCOyZEXVbEriluMJn0hz28vszVb4Cr2IA4YQ9cnERqjHaf33MHIRBQ==",
             "hasInstallScript": true,
             "dependencies": {
-                "@mapbox/geojson-rewind": "^0.5.1",
+                "@mapbox/geojson-rewind": "^0.5.2",
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",
                 "@mapbox/mapbox-gl-supported": "^2.0.1",
                 "@mapbox/point-geometry": "^0.1.0",
-                "@mapbox/tiny-sdf": "^2.0.4",
+                "@mapbox/tiny-sdf": "^2.0.5",
                 "@mapbox/unitbezier": "^0.0.1",
                 "@mapbox/vector-tile": "^1.3.1",
                 "@mapbox/whoots-js": "^3.1.0",
-                "@types/geojson": "^7946.0.8",
+                "@types/geojson": "^7946.0.10",
                 "@types/mapbox__point-geometry": "^0.1.2",
                 "@types/mapbox__vector-tile": "^1.3.0",
                 "@types/pbf": "^3.0.2",
                 "csscolorparser": "~1.0.3",
-                "earcut": "^2.2.3",
+                "earcut": "^2.2.4",
                 "geojson-vt": "^3.2.1",
                 "gl-matrix": "^3.4.3",
                 "murmurhash-js": "^1.0.0",
                 "pbf": "^3.2.1",
                 "potpack": "^1.0.2",
                 "quickselect": "^2.0.0",
-                "supercluster": "^7.1.4",
+                "supercluster": "^7.1.5",
                 "tinyqueue": "^2.0.3",
                 "vt-pbf": "^3.1.3"
             }
@@ -9169,12 +9169,12 @@
             }
         },
         "@mapbox/geojson-rewind": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz",
-            "integrity": "sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+            "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
             "requires": {
                 "get-stream": "^6.0.1",
-                "minimist": "^1.2.5"
+                "minimist": "^1.2.6"
             }
         },
         "@mapbox/jsonlint-lines-primitives": {
@@ -10384,9 +10384,9 @@
             }
         },
         "earcut": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-            "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+            "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
         },
         "electron-to-chromium": {
             "version": "1.3.846",
@@ -11686,31 +11686,31 @@
             }
         },
         "maplibre-gl": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.1.9.tgz",
-            "integrity": "sha512-pnWJmILeZpgA5QSI7K7xFK3yrkyYTd9srw3fCi2Ca52Phm78hsznPwUErEQcZLfxXKn/1h9t8IPdj0TH0NBNbg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.2.0.tgz",
+            "integrity": "sha512-5LB7ROIxvBADPa4PmU2j+mp0jG5IIbEidCOyZEXVbEriluMJn0hz28vszVb4Cr2IA4YQ9cnERqjHaf33MHIRBQ==",
             "requires": {
-                "@mapbox/geojson-rewind": "^0.5.1",
+                "@mapbox/geojson-rewind": "^0.5.2",
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",
                 "@mapbox/mapbox-gl-supported": "^2.0.1",
                 "@mapbox/point-geometry": "^0.1.0",
-                "@mapbox/tiny-sdf": "^2.0.4",
+                "@mapbox/tiny-sdf": "^2.0.5",
                 "@mapbox/unitbezier": "^0.0.1",
                 "@mapbox/vector-tile": "^1.3.1",
                 "@mapbox/whoots-js": "^3.1.0",
-                "@types/geojson": "^7946.0.8",
+                "@types/geojson": "^7946.0.10",
                 "@types/mapbox__point-geometry": "^0.1.2",
                 "@types/mapbox__vector-tile": "^1.3.0",
                 "@types/pbf": "^3.0.2",
                 "csscolorparser": "~1.0.3",
-                "earcut": "^2.2.3",
+                "earcut": "^2.2.4",
                 "geojson-vt": "^3.2.1",
                 "gl-matrix": "^3.4.3",
                 "murmurhash-js": "^1.0.0",
                 "pbf": "^3.2.1",
                 "potpack": "^1.0.2",
                 "quickselect": "^2.0.0",
-                "supercluster": "^7.1.4",
+                "supercluster": "^7.1.5",
                 "tinyqueue": "^2.0.3",
                 "vt-pbf": "^3.1.3"
             }

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -101,7 +101,7 @@
         "immutability-helper": "^3.1.1",
         "lodash": "^4.17.21",
         "luxon": "^2.5.0",
-        "maplibre-gl": "2.1.9",
+        "maplibre-gl": "2.2.0",
         "markdown-it": "^12.0.4",
         "markdown-it-link-attributes": "^3.0.0",
         "markdown-it-mark": "^3.0.1",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -101,7 +101,7 @@
         "immutability-helper": "^3.1.1",
         "lodash": "^4.17.21",
         "luxon": "^2.5.0",
-        "maplibre-gl": "2.2.0",
+        "maplibre-gl": "2.2.1",
         "markdown-it": "^12.0.4",
         "markdown-it-link-attributes": "^3.0.0",
         "markdown-it-mark": "^3.0.1",

--- a/packages/visualizations/src/components/Map/WebGl/ChoroplethGeoJson.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/ChoroplethGeoJson.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import turfBbox from '@turf/bbox';
-    import type { FilterSpecification, SourceSpecification } from 'maplibre-gl';
+    import type { ExpressionSpecification, SourceSpecification, GestureOptions } from 'maplibre-gl';
     import type { BBox, FeatureCollection } from 'geojson';
     import { debounce } from 'lodash';
     import type { ColorScale, DataBounds, Color, Source } from '../../types';
@@ -43,6 +43,7 @@
     let navigationMaps: NavigationMap[] | undefined;
     // Data source link
     let sourceLink: Source | undefined;
+    let cooperativeGestures: boolean | GestureOptions | undefined;
 
     // Used to apply a chosen color for shapes without values (default: #cccccc)
     let emptyValueColor: Color;
@@ -66,6 +67,7 @@
         description,
         navigationMaps,
         sourceLink,
+        cooperativeGestures,
     } = options);
 
     // Choropleth is always display over a blank map, for readability purposes
@@ -81,7 +83,7 @@
         values: ChoroplethDataValue[] = []
     ) {
         let colors;
-        let fillColor: string | (string | string[])[] | FilterSpecification = emptyValueColor;
+        let fillColor: string | ExpressionSpecification = emptyValueColor;
 
         if (values.length > 0) {
             dataBounds = getDataBounds(values);
@@ -131,6 +133,7 @@
         {navigationMaps}
         {data}
         {sourceLink}
+        {cooperativeGestures}
     />
 </div>
 

--- a/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { FilterSpecification, SourceSpecification } from 'maplibre-gl';
+    import type { FilterSpecification, SourceSpecification, ExpressionSpecification, GestureOptions } from 'maplibre-gl';
     import type { BBox } from 'geojson';
     import { debounce } from 'lodash';
     import type { ColorScale, DataBounds, Color, Source } from '../../types';
@@ -47,6 +47,7 @@
     let navigationMaps: NavigationMap[] | undefined;
     // Data source link
     let sourceLink: Source | undefined;
+    let cooperativeGestures: boolean | GestureOptions | undefined;
 
     // Used to apply a chosen color for shapes without values (default: #cccccc)
     let emptyValueColor: Color;
@@ -73,6 +74,7 @@
         description,
         navigationMaps,
         sourceLink,
+        cooperativeGestures,
     } = options);
 
     // Choropleth is always display over a blank map, for readability purposes
@@ -91,7 +93,7 @@
         values: ChoroplethDataValue[] = []
     ) {
         let colors;
-        let fillColor: string | (string | string[])[] | FilterSpecification = emptyValueColor;
+        let fillColor: string | ExpressionSpecification = emptyValueColor;
 
         if (values.length > 0) {
             dataBounds = getDataBounds(values);
@@ -150,6 +152,7 @@
     {navigationMaps}
     {data}
     {sourceLink}
+    {cooperativeGestures}
 />
 
 <style>

--- a/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { FilterSpecification, SourceSpecification, ExpressionSpecification, GestureOptions } from 'maplibre-gl';
+    import type { SourceSpecification, GestureOptions, ExpressionSpecification } from 'maplibre-gl';
     import type { BBox } from 'geojson';
     import { debounce } from 'lodash';
     import type { ColorScale, DataBounds, Color, Source } from '../../types';
@@ -40,7 +40,7 @@
     let legend: MapLegend | undefined;
     let attribution: string | undefined;
     let filter: MapFilter | undefined;
-    let filterExpression: FilterSpecification | undefined;
+    let filterExpression: ExpressionSpecification | undefined;
     let title: string | undefined;
     let subtitle: string | undefined;
     let description: string | undefined;

--- a/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
@@ -430,7 +430,7 @@
     }
     /* Add a more opacity and blur effect on map when cooperative gesture is shown */
     .map-card :global(.maplibregl-cooperative-gesture-screen) {
-        background: rgba(0,0,0,0.6);
+        background: rgba(0, 0, 0, 0.6);
         backdrop-filter: blur(2px);
     }
     .main {

--- a/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
@@ -11,6 +11,7 @@
         MapLayerMouseEvent,
         LngLatLike,
         FilterSpecification,
+        GestureOptions,
     } from 'maplibre-gl';
     import { onMount } from 'svelte';
     import { debounce } from 'lodash';
@@ -67,6 +68,7 @@
     export let data: { value: ChoroplethDataValue[] };
     // Data source link
     export let sourceLink: Source | undefined;
+    export let cooperativeGestures: boolean | GestureOptions | undefined;
 
     let clientWidth: number;
     let legendVariant: LegendVariant;
@@ -123,6 +125,7 @@
             zoom: 5,
             customAttribution: attribution,
             renderWorldCopies: false,
+            cooperativeGestures,
         };
 
         map = new maplibregl.Map({
@@ -425,7 +428,11 @@
         border-left-color: transparent;
         border-right-color: transparent;
     }
-
+    /* Add a more opacity and blur effect on map when cooperative gesture is shown */
+    .map-card :global(.maplibregl-cooperative-gesture-screen) {
+        background: rgba(0,0,0,0.6);
+        backdrop-filter: blur(2px);
+    }
     .main {
         aspect-ratio: var(--aspect-ratio);
         flex-grow: 1;
@@ -438,7 +445,6 @@
         justify-content: flex-start;
         pointer-events: var(--buttons-events);
     }
-
     /* Suitable for elements that are used via aria-describedby or aria-labelledby */
     .a11y-invisible-description {
         display: none;

--- a/packages/visualizations/src/components/Map/types.ts
+++ b/packages/visualizations/src/components/Map/types.ts
@@ -1,5 +1,5 @@
 import type { Feature, FeatureCollection, Position, BBox } from 'geojson';
-import type { FillLayerSpecification, Popup } from 'maplibre-gl';
+import type { FillLayerSpecification, Popup, GestureOptions } from 'maplibre-gl';
 import type { DebouncedFunc } from 'lodash';
 import type { LegendPositions } from '../Legend/types';
 import type { ColorScale, Color, Source } from '../types';
@@ -46,6 +46,7 @@ export interface ChoroplethOptions {
     navigationMaps?: NavigationMap[];
     /** Link button to source */
     sourceLink?: Source;
+    cooperativeGestures?: boolean | GestureOptions;
 }
 
 export interface MapFilter {

--- a/packages/visualizations/src/components/Map/utils.ts
+++ b/packages/visualizations/src/components/Map/utils.ts
@@ -222,10 +222,15 @@ export const getFixedTooltips = (
 /** Transform a filter object from the options into a Maplibre filter expression */
 export const computeFilterExpression = (filterConfig: MapFilter): ExpressionSpecification => {
     const { key, value } = filterConfig;
-    const filterMatchExpression: ExpressionSpecification = ['in', ['downcase', ['get', key]], ['literal', []]];
+    const filterMatchExpression: ExpressionSpecification = [
+        'in',
+        ['downcase', ['get', key]],
+        ['literal', []],
+    ];
 
     const matchingValues: string[] = Array.isArray(value)
-    ? value.map(v => v.toString().toLowerCase()) : [value.toString().toLowerCase()];
+        ? value.map((v) => v.toString().toLowerCase())
+        : [value.toString().toLowerCase()];
 
     filterMatchExpression[2] = ['literal', matchingValues];
     return filterMatchExpression;
@@ -287,13 +292,13 @@ export const computeMatchExpression = (
     matchKey: string,
     emptyValueColor: Color
 ): ExpressionSpecification => {
-    const matchExpression: ["match", ExpressionSpecification] = ['match', ['get', matchKey]];
+    const matchExpression: ['match', ExpressionSpecification] = ['match', ['get', matchKey]];
     const groupByColors: ExpressionInputType[] = [];
     Object.entries(colors).forEach((e) => groupByColors.push(...e));
     groupByColors.push(emptyValueColor); // Default fallback color
     // We constructed a match expression so we can cast here the final type
     return [
         ...matchExpression,
-        ...groupByColors as [ExpressionInputType, ExpressionInputType, ExpressionInputType]
+        ...(groupByColors as [ExpressionInputType, ExpressionInputType, ExpressionInputType]),
     ];
 };

--- a/packages/visualizations/src/components/Map/utils.ts
+++ b/packages/visualizations/src/components/Map/utils.ts
@@ -6,8 +6,14 @@ import type { Feature, FeatureCollection, Position, BBox } from 'geojson';
 import type { Scale } from 'chroma-js';
 import { DEFAULT_COLORS } from './constants';
 import { assertUnreachable } from '../utils';
-import { ColorScaleTypes } from '../types';
-import type { Color, ColorScale, DataBounds } from '../types';
+import {
+    Color,
+    ColorScale,
+    DataBounds,
+    isGroupByForMatchExpression,
+    ColorScaleTypes,
+} from '../types';
+
 import type {
     ChoroplethDataValue,
     ChoroplethFixedTooltipDescription,
@@ -296,9 +302,8 @@ export const computeMatchExpression = (
     const groupByColors: ExpressionInputType[] = [];
     Object.entries(colors).forEach((e) => groupByColors.push(...e));
     groupByColors.push(emptyValueColor); // Default fallback color
-    // We constructed a match expression so we can cast here the final type
-    return [
-        ...matchExpression,
-        ...(groupByColors as [ExpressionInputType, ExpressionInputType, ExpressionInputType]),
-    ];
+    if (!isGroupByForMatchExpression(groupByColors)) {
+        throw new Error('Not the expected type for complete match expression');
+    }
+    return [...matchExpression, ...groupByColors];
 };

--- a/packages/visualizations/src/components/Map/utils.ts
+++ b/packages/visualizations/src/components/Map/utils.ts
@@ -1,6 +1,6 @@
 import chroma from 'chroma-js';
 import turfBbox from '@turf/bbox';
-import maplibregl, { ExpressionSpecification, ExpressionInputType } from 'maplibre-gl';
+import maplibregl, { ExpressionInputType, ExpressionSpecification } from 'maplibre-gl';
 import geoViewport from '@mapbox/geo-viewport';
 import type { Feature, FeatureCollection, Position, BBox } from 'geojson';
 import type { Scale } from 'chroma-js';
@@ -222,17 +222,13 @@ export const getFixedTooltips = (
 /** Transform a filter object from the options into a Maplibre filter expression */
 export const computeFilterExpression = (filterConfig: MapFilter): ExpressionSpecification => {
     const { key, value } = filterConfig;
-    // The matching is case-insensitive to make it easier with unique administrative codes
-    // that may have varying case but still represent the same entity.
-    // FIXME: better typing and check if impact on usage
-    const filterMatchExpression: any = ['in', ['downcase', ['get', key]]];
-    const matchingValues: ExpressionInputType[] = [];
-    (Array.isArray(value) ? value : [value]).forEach((filterValue) => {
-        matchingValues.push(filterValue.toString().toLowerCase());
-    });
-    const additionalExpression: ['literal', ExpressionInputType[]] = ['literal', matchingValues];
-    filterMatchExpression.push(additionalExpression);
-    return filterMatchExpression as ExpressionSpecification;
+    const filterMatchExpression: ExpressionSpecification = ['in', ['downcase', ['get', key]], ['literal', []]];
+
+    const matchingValues: string[] = Array.isArray(value)
+    ? value.map(v => v.toString().toLowerCase()) : [value.toString().toLowerCase()];
+
+    filterMatchExpression[2] = ['literal', matchingValues];
+    return filterMatchExpression;
 };
 
 export const defaultTooltipFormat: ChoroplethTooltipFormatter = ({ value, label }) =>

--- a/packages/visualizations/src/components/MapPoi/Map.svelte
+++ b/packages/visualizations/src/components/MapPoi/Map.svelte
@@ -37,6 +37,7 @@
         aspectRatio,
         interactive,
         transformRequest,
+        cooperativeGestures,
     } = getMapOptions(options));
 
     const bbox = createDeepEqual(_bbox);
@@ -65,6 +66,7 @@
             {aspectRatio}
             {interactive}
             {transformRequest}
+            {cooperativeGestures}
         />
     {/key}
 </div>

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
     import type { BBox } from 'geojson';
-    import type { LngLatBoundsLike, LngLatLike, MapOptions, StyleSpecification } from 'maplibre-gl';
+    import type { LngLatBoundsLike, LngLatLike, MapOptions, StyleSpecification, GestureOptions } from 'maplibre-gl';
     import { onDestroy, onMount } from 'svelte';
     import CategoryLegend from '../Legend/CategoryLegend.svelte';
     import type { CategoryLegend as CategoryLegendType } from '../Legend/types';
@@ -31,6 +31,7 @@
     export let subtitle: string | undefined;
     export let legend: CategoryLegendType | undefined;
     export let description: string | undefined;
+    export let cooperativeGestures: boolean | GestureOptions | undefined;
     // Data source link
     export let sourceLink: Source | undefined;
 
@@ -63,6 +64,7 @@
             transformRequest,
             minZoom,
             maxZoom,
+            cooperativeGestures,
         };
         map.initialize(style, container, options);
     });
@@ -144,6 +146,11 @@
         padding: 13px;
         border-radius: 6px;
         box-shadow: 0 6px 13px 0 rgba(0, 0, 0, 0.26);
+    }
+    /* Add a more opacity and blur effect on map when cooperative gesture is shown */
+    .map-card :global(.maplibregl-cooperative-gesture-screen) {
+        background: rgba(0,0,0,0.6);
+        backdrop-filter: blur(2px);
     }
     .main {
         aspect-ratio: var(--aspect-ratio);

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -2,7 +2,13 @@
 
 <script lang="ts">
     import type { BBox } from 'geojson';
-    import type { LngLatBoundsLike, LngLatLike, MapOptions, StyleSpecification, GestureOptions } from 'maplibre-gl';
+    import type {
+        LngLatBoundsLike,
+        LngLatLike,
+        MapOptions,
+        StyleSpecification,
+        GestureOptions,
+    } from 'maplibre-gl';
     import { onDestroy, onMount } from 'svelte';
     import CategoryLegend from '../Legend/CategoryLegend.svelte';
     import type { CategoryLegend as CategoryLegendType } from '../Legend/types';
@@ -149,7 +155,7 @@
     }
     /* Add a more opacity and blur effect on map when cooperative gesture is shown */
     .map-card :global(.maplibregl-cooperative-gesture-screen) {
-        background: rgba(0,0,0,0.6);
+        background: rgba(0, 0, 0, 0.6);
         backdrop-filter: blur(2px);
     }
     .main {

--- a/packages/visualizations/src/components/MapPoi/types.ts
+++ b/packages/visualizations/src/components/MapPoi/types.ts
@@ -4,6 +4,7 @@ import type {
     GeoJSONFeature,
     LngLatLike,
     RequestTransformFunction,
+    GestureOptions,
 } from 'maplibre-gl';
 import type { BBox, GeoJsonProperties } from 'geojson';
 
@@ -50,6 +51,7 @@ export interface PoiMapOptions {
     legend?: CategoryLegend;
     /** Link button to source */
     sourceLink?: Source;
+    cooperativeGestures?: boolean | GestureOptions;
 }
 
 export type PoiMapStyleOption = Partial<Pick<StyleSpecification, 'sources' | 'layers'>>;

--- a/packages/visualizations/src/components/MapPoi/utils.ts
+++ b/packages/visualizations/src/components/MapPoi/utils.ts
@@ -6,7 +6,7 @@ import type {
     ExpressionInputType,
 } from 'maplibre-gl';
 
-import type { Color } from '../types';
+import { isGroupByForMatchExpression, type Color } from '../types';
 
 import type {
     CenterZoomOptions,
@@ -55,13 +55,12 @@ export const getMapLayers = (layers?: Layer[]): CircleLayerSpecification[] => {
                 groupByColors.push(color, colors[color]);
             });
             groupByColors.push(layerColor);
+            if (!isGroupByForMatchExpression(groupByColors)) {
+                throw new Error('Not the expected type for complete match expression');
+            }
             circleColor = [
                 ...matchExpression,
-                ...(groupByColors as [
-                    ExpressionInputType,
-                    ExpressionInputType,
-                    ExpressionInputType
-                ]),
+                ...groupByColors,
             ];
 
             if (borderColors) {
@@ -74,14 +73,12 @@ export const getMapLayers = (layers?: Layer[]): CircleLayerSpecification[] => {
                     groupByBorderColors.push(borderColor, borderColors[borderColor]);
                 });
                 groupByBorderColors.push(circleBorderColor || DEFAULT_DARK_GREY);
-                // We constructed a match expression so we can cast here the final type
+                if (!isGroupByForMatchExpression(groupByBorderColors)) {
+                    throw new Error('Not the expected type for complete match expression');
+                }
                 circleBorderColor = [
                     ...matchBorderExpression,
-                    ...(groupByBorderColors as [
-                        ExpressionInputType,
-                        ExpressionInputType,
-                        ExpressionInputType
-                    ]),
+                    ...groupByBorderColors,
                 ];
             }
         }

--- a/packages/visualizations/src/components/MapPoi/utils.ts
+++ b/packages/visualizations/src/components/MapPoi/utils.ts
@@ -45,12 +45,11 @@ export const getMapLayers = (layers?: Layer[]): CircleLayerSpecification[] => {
         } = layer;
 
         let circleColor: ExpressionSpecification | Color = layerColor;
-        let circleBorderColor: ExpressionSpecification | Color | undefined =
-            layerBorderColor;
+        let circleBorderColor: ExpressionSpecification | Color | undefined = layerBorderColor;
 
         if (colorMatch) {
             const { key, colors, borderColors } = colorMatch;
-            const matchExpression: ["match", ExpressionSpecification] = ['match', ['get', key]];
+            const matchExpression: ['match', ExpressionSpecification] = ['match', ['get', key]];
             const groupByColors: ExpressionInputType[] = [];
             Object.keys(colors).forEach((color) => {
                 groupByColors.push(color, colors[color]);
@@ -58,11 +57,18 @@ export const getMapLayers = (layers?: Layer[]): CircleLayerSpecification[] => {
             groupByColors.push(layerColor);
             circleColor = [
                 ...matchExpression,
-                ...groupByColors as [ExpressionInputType, ExpressionInputType, ExpressionInputType]
+                ...(groupByColors as [
+                    ExpressionInputType,
+                    ExpressionInputType,
+                    ExpressionInputType
+                ]),
             ];
 
             if (borderColors) {
-                const matchBorderExpression: ["match", ExpressionSpecification] = ['match', ['get', key]];
+                const matchBorderExpression: ['match', ExpressionSpecification] = [
+                    'match',
+                    ['get', key],
+                ];
                 const groupByBorderColors: ExpressionInputType[] = [];
                 Object.keys(borderColors).forEach((borderColor) => {
                     groupByBorderColors.push(borderColor, borderColors[borderColor]);
@@ -71,7 +77,11 @@ export const getMapLayers = (layers?: Layer[]): CircleLayerSpecification[] => {
                 // We constructed a match expression so we can cast here the final type
                 circleBorderColor = [
                     ...matchBorderExpression,
-                    ...groupByBorderColors as [ExpressionInputType, ExpressionInputType, ExpressionInputType]
+                    ...(groupByBorderColors as [
+                        ExpressionInputType,
+                        ExpressionInputType,
+                        ExpressionInputType
+                    ]),
                 ];
             }
         }

--- a/packages/visualizations/src/components/MapPoi/utils.ts
+++ b/packages/visualizations/src/components/MapPoi/utils.ts
@@ -6,7 +6,7 @@ import type {
     ExpressionInputType,
 } from 'maplibre-gl';
 
-import { isGroupByForMatchExpression, type Color } from '../types';
+import { isGroupByForMatchExpression, Color } from '../types';
 
 import type {
     CenterZoomOptions,
@@ -58,10 +58,7 @@ export const getMapLayers = (layers?: Layer[]): CircleLayerSpecification[] => {
             if (!isGroupByForMatchExpression(groupByColors)) {
                 throw new Error('Not the expected type for complete match expression');
             }
-            circleColor = [
-                ...matchExpression,
-                ...groupByColors,
-            ];
+            circleColor = [...matchExpression, ...groupByColors];
 
             if (borderColors) {
                 const matchBorderExpression: ['match', ExpressionSpecification] = [
@@ -76,10 +73,7 @@ export const getMapLayers = (layers?: Layer[]): CircleLayerSpecification[] => {
                 if (!isGroupByForMatchExpression(groupByBorderColors)) {
                     throw new Error('Not the expected type for complete match expression');
                 }
-                circleBorderColor = [
-                    ...matchBorderExpression,
-                    ...groupByBorderColors,
-                ];
+                circleBorderColor = [...matchBorderExpression, ...groupByBorderColors];
             }
         }
         return {

--- a/packages/visualizations/src/components/types.ts
+++ b/packages/visualizations/src/components/types.ts
@@ -39,6 +39,12 @@ export type ColorScale = GradientScale | PaletteScale;
 // We expect an array with couples of values and ExpressionInput and for the last element a default ExpressionInput
 export function isGroupByForMatchExpression(
     value: ExpressionInputType[]
-): value is [ExpressionInputType, ExpressionInputType, ExpressionInputType] {
+): value is [
+    ExpressionInputType,
+    ExpressionInputType,
+    ExpressionInputType,
+    ...ExpressionInputType[],
+    ExpressionInputType
+] {
     return value.length >= 3 && value.length % 2 === 1;
 }

--- a/packages/visualizations/src/components/types.ts
+++ b/packages/visualizations/src/components/types.ts
@@ -1,3 +1,5 @@
+import type { ExpressionInputType } from 'maplibre-gl';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DataFrame = Record<string, any>[];
 
@@ -33,3 +35,10 @@ export type PaletteScale = {
 };
 
 export type ColorScale = GradientScale | PaletteScale;
+
+// We expect an array with couples of values and ExpressionInput and for the last element a default ExpressionInput
+export function isGroupByForMatchExpression(
+    value: ExpressionInputType[]
+): value is [ExpressionInputType, ExpressionInputType, ExpressionInputType] {
+    return value.length >= 3 && value.length % 2 === 1;
+}


### PR DESCRIPTION
## Summary

The goal for this PR is to add the option of cooperative gestures for maps, both POI and Choropleth.

This PR needs an update of Maplibre at least up to version 2.2.0 but as the version 2.2.1 fixes some typings issue on Maplibre expressions, it seems better to already update to 2.2.1.

I had troubles to fix the way we defined `FilterExpression`, If you see better solutions, please let me know ! And also this upgrade will have consequences for our users, some types changes will be necessary even if it doesn't appear heavy.

Please check if there is no regression due to the types changes (I've slightly changed the way the functions are made)

There is a change in Chromatic that I can't really explain: https://www.chromatic.com/test?appId=616594e84c1692003af430f3&id=655b8ed6701077f47cbd3365. It doesn't affect many stories so this must be really niche.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-44646](https://app.shortcut.com/opendatasoft/story/44646/studio-poi-maps-choropleth-zoom-on-maps-while-holding-control-command).

### Changes

- Update Maplibre to 2.2.1
- Adapt types changes on Maplibre expressions
- Add some CSS to default cooperative gesture screen rules.

## Open discussion

Do you see better typing changes ?

## To be tested

Regression and Chromatic tests 🙏 

## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
