### PR TITLE
[FIX][SC-45182]  Switch between tooltip should not require to close tooltip

### DIFF
--- a/packages/visualizations/src/components/MapPoi/constants.ts
+++ b/packages/visualizations/src/components/MapPoi/constants.ts
@@ -17,5 +17,5 @@ export const POPUP_WIDTH = 300;
 export const POPUP_OPTIONS: PopupOptions = {
     className: 'poi-map__popup',
     closeButton: false,
-    maxWidth: `${POPUP_WIDTH}px`,
+    closeOnClick: false,
 };


### PR DESCRIPTION
This PR targets https://github.com/opendatasoft/ods-dataviz-sdk/pull/205. 

In https://github.com/opendatasoft/ods-dataviz-sdk/pull/205, the tooltip behavior changes a bit to adapt when the map width is small. In order catch any weird conflicts or behaviors that can arise, I decided not to start from `main` when creating this branch.
=> Didn't see anything weird

## Summary

The goal for this PR is to fix the opening and closing mechanism for POI tooltip.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-45182](https://app.shortcut.com/opendatasoft/story/45182).

https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/53cdf037-a40a-4dc1-a7a2-178d4a8ccc49

### Changes

- The main change is that we no longer depend on Maplibre to close the tooltip. (the popup option: `closeOnClick` is now `false`). Tooltips close when :
   - User clicks on the map where no feature are present
   - User clicks on the close icon button
- We no longer save features retrieved from a click. But instead we save the actual feature used to display content in the tooltip.
- A click on a feature for which a tooltip is open, close the tooltip


## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
