### PR TITLE
chore: update category legend style grid to 120 px width

### DIFF
--- a/packages/visualizations/src/components/Legend/CategoryLegend.svelte
+++ b/packages/visualizations/src/components/Legend/CategoryLegend.svelte
@@ -51,7 +51,7 @@
         display: grid;
         justify-content: var(--align);
         grid-gap: 3px 13px;
-        grid-template-columns: repeat(auto-fit, minmax(80px, max-content));
+        grid-template-columns: repeat(auto-fit, minmax(120px, max-content));
         padding: 13px 0;
     }
 </style>


### PR DESCRIPTION
## Summary

The goal for this PR is to update the category legend css grid from 80 px to 120px (design request) Some changes will impact the graphs used by other teams but it appears that they follow the design changes.

## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
