### PR TITLE
feat(POI maps): add navigation controls for multi features popup

### DIFF
--- a/packages/visualizations-react/stories/Poi/PoiMap.stories.tsx
+++ b/packages/visualizations-react/stories/Poi/PoiMap.stories.tsx
@@ -57,8 +57,20 @@ const layers = [layer1, layer2];
 
 const citiesColorMatch = {
     key: 'key',
-    colors: { Paris: 'blue', Nantes: 'yellow', Bordeaux: 'purple', Marseille: 'lightblue' },
-    borderColors: { Paris: 'white', Nantes: 'black', Bordeaux: 'white', Marseille: 'black' },
+    colors: {
+        Paris: 'blue',
+        'Paris--duplicate': 'lightblue',
+        Nantes: 'yellow',
+        Bordeaux: 'purple',
+        Marseille: 'lightblue',
+    },
+    borderColors: {
+        Paris: 'white',
+        'Paris--duplicate': 'white',
+        Nantes: 'black',
+        Bordeaux: 'white',
+        Marseille: 'black',
+    },
 };
 
 const battleImageMatch = {

--- a/packages/visualizations-react/stories/Poi/sources.ts
+++ b/packages/visualizations-react/stories/Poi/sources.ts
@@ -15,12 +15,24 @@ const sources : PoiMapData["sources"] = {
                         coordinates: [2.357573,48.837904],
                     },
                     properties: {
+                        key: 'Paris--duplicate',
+                        description: 'Same location as Paris'
+                    },
+                },
+                {
+                    id: 2,
+                    type: 'Feature',
+                    geometry: {
+                        type: 'Point',
+                        coordinates: [2.357573,48.837904],
+                    },
+                    properties: {
                         key: 'Paris',
                         description: 'Officia deserunt commodo enim ea ad veniam enim consectetur aliquip adipisicing duis. Exercitation aute velit pariatur est et ea qui veniam ad duis quis ad aliquip. Ipsum exercitation dolor tempor deserunt sunt amet laborum tempor excepteur est sunt ea quis.'
                     },
                 },
                 {
-                    id: 2,
+                    id: 3,
                     type: 'Feature',
                     geometry: {
                         type: 'Point',
@@ -32,7 +44,7 @@ const sources : PoiMapData["sources"] = {
                     },
                 },
                 {
-                    id: 3,
+                    id: 4,
                     type: 'Feature',
                     geometry: {
                         type: 'Point',
@@ -44,7 +56,7 @@ const sources : PoiMapData["sources"] = {
                     },
                 },
                 {
-                    id: 4,
+                    id: 5,
                     type: 'Feature',
                     geometry: {
                         type: 'Point',

--- a/packages/visualizations/src/components/MapPoi/Map.ts
+++ b/packages/visualizations/src/components/MapPoi/Map.ts
@@ -191,12 +191,12 @@ export default class MapPOI {
         popupNavigationDiv.innerHTML = `
                 <div class="${POPUP_NAVIGATION_CONTROLS_CLASSNAME}">
                     <button class="${POPUP_NAVIGATION_ARROW_CLASSNAME}" id="prevButton" ${
-                        activeFeatureHumanIndex === 1 ? 'disabled' : ''
-                    }><</button>
+            activeFeatureHumanIndex === 1 ? 'disabled' : ''
+        }><</button>
                     <div class="feature-count">${activeFeatureHumanIndex} / ${availableFeaturesTotal}</div>
                     <button class="${POPUP_NAVIGATION_ARROW_CLASSNAME}" id="nextButton" ${
-                        activeFeatureHumanIndex === availableFeaturesTotal ? 'disabled' : ''
-                    }>></button>
+            activeFeatureHumanIndex === availableFeaturesTotal ? 'disabled' : ''
+        }>></button>
                 </div>
             `;
 

--- a/packages/visualizations/src/components/MapPoi/Map.ts
+++ b/packages/visualizations/src/components/MapPoi/Map.ts
@@ -164,11 +164,22 @@ export default class MapPOI {
                     );
                     break;
                 case 'circle':
-                    map.setPaintProperty(
-                        layer.id,
-                        'circle-radius',
-                        (layer as CircleLayerSpecification).paint?.['circle-radius']
-                    );
+                    // eslint-disable-next-line no-case-declarations
+                    const circleRadius = (layer as CircleLayerSpecification).paint?.[
+                        'circle-radius'
+                    ];
+                    /*
+                     * FIXME: As of Maplibre 2.2.1, resetting 'circle-radius' with a numeric value alone is not sufficient.
+                     * An expression with a case statement based on the feature ID is still required.
+                     * Without this, the feature's clickability is compromised, as the hitbox becomes minimal,
+                     * failing to reflect the expected behavior of the circleRadius property.
+                     */
+                    map.setPaintProperty(layer.id, 'circle-radius', [
+                        'case',
+                        ['==', ['id'], ''],
+                        circleRadius,
+                        circleRadius,
+                    ]);
                     break;
                 default:
                     break;

--- a/packages/visualizations/src/components/MapPoi/Map.ts
+++ b/packages/visualizations/src/components/MapPoi/Map.ts
@@ -387,6 +387,7 @@ export default class MapPOI {
     destroy() {
         this.activePopupDisplay = null;
         this.activeFeature = null;
+        this.availableFeaturesOnClick = [];
         this.popup.remove();
         this.queue((map) => map.remove());
         this.mapResizeObserver?.disconnect();

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -209,7 +209,7 @@
         --navigation-button-size: 36px;
         position: relative;
         display: flex;
-        justify-content: end;
+        justify-content: flex-end;
         gap: 6px;
         margin: 6px;
         max-height: var(--navigation-button-size);

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -59,7 +59,7 @@
     $: map.setMinZoom(minZoom);
     $: map.setMaxZoom(maxZoom);
     $: map.setSourcesAndLayers(sources, layers);
-    $: map.setpopupConfigurationByLayers(popupConfigurationByLayers);
+    $: map.setPopupConfigurationByLayers(popupConfigurationByLayers);
     $: map.jumpTo(getCenterZoomOptions({ zoom, center }));
     $: map.loadImages(images);
     $: cssVarStyles = `--aspect-ratio:${aspectRatio};`;
@@ -177,13 +177,17 @@
         display: flex;
         flex-direction: column;
         flex-wrap: nowrap;
-        padding: 13px;
+        padding: 0px;
         border-radius: 6px;
         max-height: 100%;
         overflow-y: auto;
         overflow-x: hidden;
         box-sizing: border-box;
         box-shadow: 0 6px 13px 0 rgba(0, 0, 0, 0.26);
+    }
+    .map-card :global(.poi-map__popup .poi-map__popup-content),
+    .map-card :global(.poi-map__popup .poi-map__popup-content--loading) {
+        margin: 13px;
     }
     /* Add a more opacity and blur effect on map when cooperative gesture is shown */
     .map-card :global(.maplibregl-cooperative-gesture-screen) {
@@ -192,43 +196,94 @@
     }
 
     /* --- POPUP CLOSE BUTTON ---  */
-    .map-card :global(.maplibregl-popup-close-button) {
-        font-size: 16px;
-        padding: 0;
-        width: 24px;
-        height: 24px;
-        margin-bottom: 13px;
-        position: relative;
-        order: -1;
-        flex-shrink: 0;
-        left: calc(100% - 26px);
-    }
-    .map-card :global(.maplibregl-popup-close-button:hover) {
-        background-color: transparent;
-    }
-    /* Hide close button when content is loading or when its display is as a tooltip */
-    .map-card :global(.poi-map__popup--loading .maplibregl-popup-close-button),
-    .map-card :global(.poi-map__popup--as-tooltip .maplibregl-popup-close-button) {
+    /* Hide close button when its display is as a tooltip */
+    .map-card :global(.poi-map__popup--as-tooltip .poi-map__popup-navigation-close-button) {
         display: none;
     }
 
     /* --- POPUP NAVIGATION CONTROLS ---  */
     .map-card :global(.poi-map__popup-navigation-controls) {
+        position: relative;
         display: flex;
+        gap: 6px;
         justify-content: center;
         align-items: center;
-        margin-bottom: 12px;
-        font-weight: 400;
+        margin: 6px 6px 0px 6px;
     }
-    .map-card :global(.poi-map__popup-navigation-arrow) {
-        margin: 6px;
+    .map-card :global(.poi-map__popup-navigation-arrow-button) {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0px;
+        width: 36px;
+        height: 36px;
+        background: none;
+        border: none;
         cursor: pointer;
+    }
+    .map-card :global(.poi-map__popup-navigation-arrow-button:disabled) {
+        cursor: not-allowed;
+    }
+    .map-card :global(.poi-map__popup-navigation-arrow-button-icon) {
+        width: 6px;
+        height: 6px;
+        border-top: 2px solid;
+        border-left: 2px solid;
+    }
+    .map-card
+        :global(#prevButton.poi-map__popup-navigation-arrow-button
+            .poi-map__popup-navigation-arrow-button-icon) {
+        transform: rotate(-45deg);
+    }
+    .map-card
+        :global(#nextButton.poi-map__popup-navigation-arrow-button
+            .poi-map__popup-navigation-arrow-button-icon) {
+        transform: rotate(135deg);
+    }
+
+    .map-card
+        :global(.poi-map__popup-navigation-arrow-button:disabled
+            .poi-map__popup-navigation-arrow-button-icon) {
+        opacity: 0.5;
+    }
+
+    .map-card :global(.poi-map__popup-navigation-close-button) {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        padding: 0px;
         border: none;
         background: none;
+        cursor: pointer;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: 0;
     }
-    .map-card :global(.poi-map__popup-navigation-arrow:disabled) {
-        cursor: not-allowed;
-        opacity: 0.5;
+    .map-card :global(.poi-map__popup-navigation-close-button-icon) {
+        position: relative;
+        display: block;
+        width: 14px;
+        height: 14px;
+    }
+
+    .map-card :global(.poi-map__popup-navigation-close-button-icon:before),
+    .map-card :global(.poi-map__popup-navigation-close-button-icon:after) {
+        position: absolute;
+        left: 6px;
+        content: '';
+        height: 100%;
+        width: 2px;
+        border-radius: 2px;
+        background-color: #333;
+    }
+    .map-card :global(.poi-map__popup-navigation-close-button-icon:before) {
+        transform: rotate(45deg);
+    }
+    .map-card :global(.poi-map__popup-navigation-close-button-icon:after) {
+        transform: rotate(-45deg);
     }
 
     /* --- CONTROLS --- */

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -185,8 +185,8 @@
         box-sizing: border-box;
         box-shadow: 0 6px 13px 0 rgba(0, 0, 0, 0.26);
     }
-    .map-card :global(.poi-map__popup .poi-map__popup-content),
-    .map-card :global(.poi-map__popup .poi-map__popup-content--loading) {
+    .map-card :global(.poi-map__popup .poi-map__popup-feature-content),
+    .map-card :global(.poi-map__popup .poi-map__popup-feature-content--loading) {
         margin: 13px;
     }
     /* Add a more opacity and blur effect on map when cooperative gesture is shown */
@@ -196,27 +196,42 @@
     }
 
     /* --- POPUP CLOSE BUTTON ---  */
-    /* Hide close button when its display is as a tooltip */
-    .map-card :global(.poi-map__popup--as-tooltip .poi-map__popup-navigation-close-button) {
+    /* Hide close button and offset when its display is as a tooltip
+     * Hidden offset allow to center the arrows wrapper
+     */
+    .map-card :global(.poi-map__popup--as-tooltip .poi-map__popup-navigation-close-button),
+    .map-card :global(.poi-map__popup--as-tooltip .poi-map__popup-navigation-controls-offset) {
         display: none;
     }
 
     /* --- POPUP NAVIGATION CONTROLS ---  */
     .map-card :global(.poi-map__popup-navigation-controls) {
+        --navigation-button-size: 36px;
         position: relative;
         display: flex;
+        justify-content: end;
         gap: 6px;
+        margin: 6px;
+        max-height: var(--navigation-button-size);
+    }
+    .map-card :global(.poi-map__popup-arrows-wrapper) {
+        flex-grow: 1;
+        display: flex;
         justify-content: center;
         align-items: center;
-        margin: 6px 6px 0px 6px;
     }
+    .map-card :global(.poi-map__popup-navigation-controls-offset) {
+        width: var(--navigation-button-size);
+        flex-shrink: 0;
+    }
+
     .map-card :global(.poi-map__popup-navigation-arrow-button) {
         display: flex;
         align-items: center;
         justify-content: center;
         padding: 0px;
-        width: 36px;
-        height: 36px;
+        width: var(--navigation-button-size);
+        height: var(--navigation-button-size);
         background: none;
         border: none;
         cursor: pointer;
@@ -251,16 +266,13 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 36px;
-        height: 36px;
+        width: var(--navigation-button-size);
+        height: var(--navigation-button-size);
         padding: 0px;
         border: none;
         background: none;
         cursor: pointer;
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        right: 0;
+        flex-shrink: 0;
     }
     .map-card :global(.poi-map__popup-navigation-close-button-icon) {
         position: relative;

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -212,6 +212,25 @@
         display: none;
     }
 
+    /* --- POPUP NAVIGATION CONTROLS ---  */
+    .map-card :global(.poi-map__popup-navigation-controls) {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-bottom: 12px;
+        font-weight: 400;
+    }
+    .map-card :global(.poi-map__popup-navigation-arrow) {
+        margin: 6px;
+        cursor: pointer;
+        border: none;
+        background: none;
+    }
+    .map-card :global(.poi-map__popup-navigation-arrow:disabled) {
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
+
     /* --- CONTROLS --- */
     .map-card :global(.maplibregl-ctrl.maplibregl-ctrl-group) {
         margin-top: 13px;

--- a/packages/visualizations/src/components/MapPoi/constants.ts
+++ b/packages/visualizations/src/components/MapPoi/constants.ts
@@ -17,12 +17,18 @@ export const POPUP_WIDTH = 300;
 
 export const CONTROL_POSITION: ControlPosition = 'top-right';
 
-// Update styles in ./MapRender.svelte if this classname changes
-export const POPUP_CLASSNAME = 'poi-map__popup';
-// Update styles in ./MapRender.svelte if this classname changes
+
+// Update styles in ./MapRender.svelte if one of these classnames must change.
+const POPUP_CLASSNAME = 'poi-map__popup';
+export const POPUP_CONTENT = 'poi-map__popup-content';
+export const POPUP_LOADING_CONTENT = 'poi-map__popup-content--loading';
 export const POPUP_NAVIGATION_CONTROLS_CLASSNAME = 'poi-map__popup-navigation-controls';
-// Update styles in ./MapRender.svelte if this classname changes
-export const POPUP_NAVIGATION_ARROW_CLASSNAME = 'poi-map__popup-navigation-arrow';
+export const POPUP_NAVIGATION_ARROW_BUTTON_CLASSNAME = 'poi-map__popup-navigation-arrow-button';
+export const POPUP_NAVIGATION_ARROW_BUTTON_ICON_CLASSNAME =
+    'poi-map__popup-navigation-arrow-button-icon';
+export const POPUP_NAVIGATION_CLOSE_BUTTON_CLASSNAME = 'poi-map__popup-navigation-close-button';
+export const POPUP_NAVIGATION_CLOSE_BUTTON_ICON_CLASSNAME =
+    'poi-map__popup-navigation-close-button-icon';
 
 export const POPUP_DISPLAY_CLASSNAME_MODIFIER: Record<PopupDisplayTypes, string> = {
     [POPUP_DISPLAY.tooltip]: `${POPUP_CLASSNAME}--as-tooltip`,
@@ -32,6 +38,6 @@ export const POPUP_DISPLAY_CLASSNAME_MODIFIER: Record<PopupDisplayTypes, string>
 
 export const POPUP_OPTIONS: PopupOptions = {
     className: POPUP_CLASSNAME,
-    closeButton: true,
+    closeButton: false,
     closeOnClick: false,
 };

--- a/packages/visualizations/src/components/MapPoi/constants.ts
+++ b/packages/visualizations/src/components/MapPoi/constants.ts
@@ -20,9 +20,12 @@ export const CONTROL_POSITION: ControlPosition = 'top-right';
 
 // Update styles in ./MapRender.svelte if one of these classnames must change.
 const POPUP_CLASSNAME = 'poi-map__popup';
-export const POPUP_CONTENT = 'poi-map__popup-content';
-export const POPUP_LOADING_CONTENT = 'poi-map__popup-content--loading';
+export const POPUP_FEATURE_CONTENT = 'poi-map__popup-feature-content';
+export const POPUP_FEATURE_CONTENT_LOADING = 'poi-map__popup-feature-content--loading';
 export const POPUP_NAVIGATION_CONTROLS_CLASSNAME = 'poi-map__popup-navigation-controls';
+export const POPUP_NAVIGATION_CONTROLS_OFFSET_CLASSNAME =
+    'poi-map__popup-navigation-controls-offset';
+export const POPUP_NAVIGATION_ARROWS_WRAPPER_CLASSNAME = 'poi-map__popup-arrows-wrapper';
 export const POPUP_NAVIGATION_ARROW_BUTTON_CLASSNAME = 'poi-map__popup-navigation-arrow-button';
 export const POPUP_NAVIGATION_ARROW_BUTTON_ICON_CLASSNAME =
     'poi-map__popup-navigation-arrow-button-icon';

--- a/packages/visualizations/src/components/MapPoi/constants.ts
+++ b/packages/visualizations/src/components/MapPoi/constants.ts
@@ -19,6 +19,10 @@ export const CONTROL_POSITION: ControlPosition = 'top-right';
 
 // Update styles in ./MapRender.svelte if this classname changes
 export const POPUP_CLASSNAME = 'poi-map__popup';
+// Update styles in ./MapRender.svelte if this classname changes
+export const POPUP_NAVIGATION_CONTROLS_CLASSNAME = 'poi-map__popup-navigation-controls';
+// Update styles in ./MapRender.svelte if this classname changes
+export const POPUP_NAVIGATION_ARROW_CLASSNAME = 'poi-map__popup-navigation-arrow';
 
 export const POPUP_DISPLAY_CLASSNAME_MODIFIER: Record<PopupDisplayTypes, string> = {
     [POPUP_DISPLAY.tooltip]: `${POPUP_CLASSNAME}--as-tooltip`,

--- a/packages/visualizations/src/components/MapPoi/constants.ts
+++ b/packages/visualizations/src/components/MapPoi/constants.ts
@@ -17,7 +17,6 @@ export const POPUP_WIDTH = 300;
 
 export const CONTROL_POSITION: ControlPosition = 'top-right';
 
-
 // Update styles in ./MapRender.svelte if one of these classnames must change.
 const POPUP_CLASSNAME = 'poi-map__popup';
 export const POPUP_FEATURE_CONTENT = 'poi-map__popup-feature-content';

--- a/packages/visualizations/src/components/MapPoi/utils.ts
+++ b/packages/visualizations/src/components/MapPoi/utils.ts
@@ -89,12 +89,7 @@ const getMapCircleLayer = (layer: CircleLayer): CircleLayerSpecification => {
         ...getBaseMapLayerConfiguration(layer),
         type,
         paint: {
-            'circle-radius': [
-                'case',
-                ['boolean', ['feature-state', 'popup-feature'], false],
-                circleRadius * 1.3,
-                circleRadius,
-            ],
+            'circle-radius': circleRadius,
             ...(circleBorderColor && { 'circle-stroke-width': circleStrokeWidth }),
             'circle-color': circleColor,
             ...(circleBorderColor && { 'circle-stroke-color': circleBorderColor }),
@@ -124,6 +119,7 @@ const getMapSymbolLayer = (layer: SymbolLayer): SymbolLayerSpecification => {
         ...getBaseMapLayerConfiguration(layer),
         type,
         layout: {
+            'icon-size': 1,
             'icon-allow-overlap': true,
             'icon-image': iconImage,
         },


### PR DESCRIPTION
## Summary

The goal for this PR is ~~to test a simple implementation~~ to add navigation controls inside the popup when the click event query multiple features.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-44648](https://app.shortcut.com/opendatasoft/story/44648/studio-poi-maps-navigate-through-records-in-the-tooltip).


https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/6babce90-e045-4f6b-948c-4ea43b883fbf



Native Popup close button has been removed to add a custom arrow which is at the same level of the navigation buttons. 

We also update how a feature is highlight. Highlight and un-highlight strategies are different for each layer type. Currently, only 'symbol' and 'circle' has highlight and un-highlight strategies.

There is a small glitch when a symbol feature is selected: the layer flickers. I didn't find why, but I think this is acceptable.

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM