### PR TITLE
[POI MAPS] Add options for images

### DIFF
--- a/packages/visualizations-react/stories/Poi/PoiMap.stories.tsx
+++ b/packages/visualizations-react/stories/Poi/PoiMap.stories.tsx
@@ -115,6 +115,16 @@ const legend = {
     align: 'start' as const,
 };
 
+const images: PoiMapOptions['images'] = {
+    'battle-icon': {
+        id: 'battle-icon',
+        url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/50/Big_battle_symbol.svg/14px-Big_battle_symbol.svg.png',
+    },
+    'battle-icon-red': {
+        id: 'battle-icon-red',
+        url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Battle_icon_gladii_red.svg/14px-Battle_icon_gladii_red.svg.png',
+    },
+};
 const options: PoiMapOptions = {
     style: BASE_STYLE,
     bbox,
@@ -122,12 +132,7 @@ const options: PoiMapOptions = {
     subtitle: 'Dolor Sit Amet',
     description: 'More aria description',
     sourceLink: defaultSource,
-    images: {
-        'battle-icon':
-            'https://upload.wikimedia.org/wikipedia/commons/thumb/5/50/Big_battle_symbol.svg/14px-Big_battle_symbol.svg.png',
-        'battle-icon-red':
-            'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Battle_icon_gladii_red.svg/14px-Battle_icon_gladii_red.svg.png',
-    },
+    images,
 };
 
 const meta: ComponentMeta<typeof PoiMap> = {

--- a/packages/visualizations/src/components/MapPoi/Map.ts
+++ b/packages/visualizations/src/components/MapPoi/Map.ts
@@ -16,7 +16,12 @@ import {
     POPUP_OPTIONS,
     POPUP_WIDTH,
 } from './constants';
-import type { PopupConfigurationByLayers, CenterZoomOptions, PopupDisplayTypes } from './types';
+import type {
+    PopupConfigurationByLayers,
+    CenterZoomOptions,
+    PopupDisplayTypes,
+    Images,
+} from './types';
 import { POPUP_DISPLAY } from './types';
 
 const CURSOR = {
@@ -392,11 +397,11 @@ export default class MapPOI {
      * Load images into the map.
      * Remove automatically any images previously loaded that are no longer defined in the images object.
      */
-    loadImages(images?: Record<string, string>) {
+    loadImages(images?: Images) {
         if (!images) return;
         this.queue((map) => {
             const loadedImages = map.listImages();
-            const imagesIds = Object.keys(images);
+            const imagesIds = Object.values(images).map(({ id }) => id);
 
             const imagesToRemove = difference(loadedImages, imagesIds);
             const imagesToAdd = difference(imagesIds, loadedImages);
@@ -406,12 +411,13 @@ export default class MapPOI {
             });
 
             imagesToAdd.forEach((imageId) => {
-                map.loadImage(images[imageId], (error, image) => {
+                const { url, options } = images[imageId];
+                map.loadImage(url, (error, image) => {
                     if (error || !image) {
                         // eslint-disable-next-line no-console
                         console.warn(`Fail to load image: ${imageId}`);
                     } else {
-                        map.addImage(imageId, image);
+                        map.addImage(imageId, image, options);
                     }
                 });
             });

--- a/packages/visualizations/src/components/MapPoi/types.ts
+++ b/packages/visualizations/src/components/MapPoi/types.ts
@@ -6,6 +6,7 @@ import type {
     LngLatLike,
     RequestTransformFunction,
     GestureOptions,
+    StyleImageMetadata,
 } from 'maplibre-gl';
 import type { BBox, GeoJsonProperties } from 'geojson';
 
@@ -18,6 +19,10 @@ export type PoiMapData = Partial<{
     layers: Layer[];
 }>;
 
+export type Images = Record<
+    string,
+    { id: string; url: string; options?: Partial<StyleImageMetadata> }
+>;
 export interface PoiMapOptions {
     /*
      * To render a basemap. Could be:
@@ -54,7 +59,7 @@ export interface PoiMapOptions {
     sourceLink?: Source;
     cooperativeGestures?: boolean | GestureOptions;
     /** Images to load by the Map. keys are image ids  */
-    images?: Record<string, string>;
+    images?: Images;
 }
 
 export type PoiMapStyleOption = Partial<Pick<StyleSpecification, 'sources' | 'layers'>>;


### PR DESCRIPTION
## Summary

The goal for this PR is to support adding images to Maps for HDI displays

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-44585](https://app.shortcut.com/opendatasoft/story/44585).
Can be tested with https://github.com/opendatasoft/platform/pull/11458

### Changes
Update the prop images to use [addImage](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#addimage) options
This allow use to add images where their dimensions do not represent their final size in the map.

For example, In the platform, for Retina displays (pixelRatio: 2), marker images with icons are given to the map as 48x48 images, but they appear as 24x24 in the map.

#### On HDI displays
|Before (blur images)|After|
|---|---|
|<img width="635" alt="Screenshot 2023-12-07 at 10 31 41" src="https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/b0e9fc53-5994-4de1-b171-160dc7880233">|<img width="635" alt="Screenshot 2023-12-07 at 10 30 32" src="https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/741f6938-7085-43e5-bbaf-c47648b5ce74">|

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
