### PR TITLE
feat: add fixed max bounds props

### DIFF
--- a/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/ChoroplethVectorTiles.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-    import type { SourceSpecification, GestureOptions, ExpressionSpecification } from 'maplibre-gl';
+    import type {
+        SourceSpecification,
+        GestureOptions,
+        ExpressionSpecification,
+        LngLatBoundsLike,
+    } from 'maplibre-gl';
     import type { BBox } from 'geojson';
     import { debounce } from 'lodash';
     import type { ColorScale, DataBounds, Color, Source } from '../../types';
@@ -48,6 +53,7 @@
     // Data source link
     let sourceLink: Source | undefined;
     let cooperativeGestures: boolean | GestureOptions | undefined;
+    let fixedMaxBounds: LngLatBoundsLike | undefined;
 
     // Used to apply a chosen color for shapes without values (default: #cccccc)
     let emptyValueColor: Color;
@@ -75,6 +81,7 @@
         navigationMaps,
         sourceLink,
         cooperativeGestures,
+        fixedMaxBounds,
     } = options);
 
     // Choropleth is always display over a blank map, for readability purposes
@@ -153,6 +160,7 @@
     {data}
     {sourceLink}
     {cooperativeGestures}
+    {fixedMaxBounds}
 />
 
 <style>

--- a/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
@@ -69,6 +69,8 @@
     // Data source link
     export let sourceLink: Source | undefined;
     export let cooperativeGestures: boolean | GestureOptions | undefined;
+    // Fixed max bounds that will overide the automatic map.getBounds when setting the bbox
+    export let fixedMaxBounds: LngLatBoundsLike | undefined | null = null;
 
     let clientWidth: number;
     let legendVariant: LegendVariant;
@@ -115,7 +117,7 @@
             padding: 40,
         });
         // Set new map max bounds after bbox changes
-        map.setMaxBounds(map.getBounds());
+        map.setMaxBounds(fixedMaxBounds || map.getBounds());
     };
 
     function initializeMap() {

--- a/packages/visualizations/src/components/Map/types.ts
+++ b/packages/visualizations/src/components/Map/types.ts
@@ -1,5 +1,5 @@
 import type { Feature, FeatureCollection, Position, BBox } from 'geojson';
-import type { FillLayerSpecification, Popup, GestureOptions } from 'maplibre-gl';
+import type { FillLayerSpecification, Popup, GestureOptions, LngLatBoundsLike } from 'maplibre-gl';
 import type { DebouncedFunc } from 'lodash';
 import type { LegendPositions } from '../Legend/types';
 import type { ColorScale, Color, Source } from '../types';
@@ -64,6 +64,8 @@ export interface ChoroplethVectorTilesOptions extends ChoroplethOptions {
     shapesTiles: ChoroplethShapeVectorTilesValue;
     /** Only draw shapes that match the given filter */
     filter?: MapFilter;
+    /** Override the default automatic adjustment of bounds from map instance, it is useful in cases where it doesn't work and, in particular, to display the world map without the extreme poles */
+    fixedMaxBounds?: LngLatBoundsLike;
 }
 
 export type NavigationMap = {


### PR DESCRIPTION
## Summary

The goal for this PR is to add a props to override the default automatic max bounds computation. It seems that with very large bbox as for example the world bbox this automatic computation causes bad rendering depending on the canvas ratio. Overriding it with a new props is not the most satisfying solution but at this point I don't see another solution.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-45683](https://app.shortcut.com/opendatasoft/story/45683/add-world-tileset-in-the-studio-choropleths).

## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
