### PR TITLE
Increase style consistency on maps

### DIFF
--- a/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
@@ -414,6 +414,9 @@
     #map {
         height: 400px;
     }
+    #map :global(canvas) {
+        cursor: default;
+    }
     @supports (aspect-ratio: auto) {
         #map {
             height: auto;

--- a/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
@@ -98,6 +98,12 @@
         className: 'tooltip-on-hover',
     }).trackPointer();
 
+    const CURSOR = {
+        DEFAULT: 'default',
+        HOVER: 'pointer',
+        DRAG: 'move',
+    };
+
     // Used in front of console and error messages to debug multiple maps on a same page
     const mapId = Math.floor(Math.random() * 1000);
     const sourceId = `shape-source-${mapId}`;
@@ -244,6 +250,15 @@
             map.keyboard.enable();
             map.scrollZoom.enable();
             map.touchZoomRotate.enable();
+
+            // Pointer style consistency across SDK maps
+            const canvas = map.getCanvas();
+            map.on('dragstart', () => {
+                canvas.style.cursor = CURSOR.DRAG;
+            });
+            map.on('dragend', () => {
+                canvas.style.cursor = CURSOR.DEFAULT;
+            });
 
             // Add navigation control to map
             if (!map.hasControl(nav)) {

--- a/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/MapRender.svelte
@@ -100,7 +100,6 @@
 
     const CURSOR = {
         DEFAULT: 'default',
-        HOVER: 'pointer',
         DRAG: 'move',
     };
 


### PR DESCRIPTION
## Summary

The goal for this PR is to harmonise the style of the cursor between all the SDK maps, to bring consistency to the use of the SDK.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-45175](https://app.shortcut.com/opendatasoft/story/45175/sdk-choropleth-map-update-cursor-style).

### Changes

Update pointer styles when it's over the map and when it's start to drag the map.

#### Breaking Changes

None...I hope

### Changelog

None

## Open discussion

Always welcome

## To be tested

Simply test hovering and dragging a map in a studio page.

## Review checklist

- [X] Description is complete
- [X] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [X] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
