### PR TITLE
[FEAT][POI Maps] Fullscreen control

### DIFF
--- a/packages/visualizations/src/components/MapPoi/constants.ts
+++ b/packages/visualizations/src/components/MapPoi/constants.ts
@@ -1,4 +1,4 @@
-import type { PopupOptions, StyleSpecification } from 'maplibre-gl';
+import type { ControlPosition, PopupOptions, StyleSpecification } from 'maplibre-gl';
 import type { Color } from '../types';
 import { POPUP_DISPLAY, PopupDisplayTypes } from './types';
 
@@ -14,6 +14,8 @@ export const DEFAULT_ASPECT_RATIO = 1;
 export const DEFAULT_DARK_GREY: Color = '#515457';
 
 export const POPUP_WIDTH = 300;
+
+export const CONTROL_POSITION: ControlPosition = 'top-right';
 
 // Update styles in ./MapRender.svelte if this classname changes
 export const POPUP_CLASSNAME = 'poi-map__popup';


### PR DESCRIPTION
## Summary

The goal for this PR is to add fullscreen controls to the POI maps

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-45176](https://app.shortcut.com/opendatasoft/story/45176).

https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/11cf964f-3dce-4869-8d25-7c87087eb47b


### Changes

Factorize functions to add / remove controls
Controls still react to the map interactivity and the active popup (if type is modal)

### Open discussions

I didn't took the time to fit to the UI described in Zeplin where controls are in the same group.
**I took the short path where most of this feature is handled natively by Maplibre.**

<img width="347" alt="Screenshot 2024-01-15 at 17 35 41" src="https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/bb27fbdf-78e0-4030-85ea-6d41fa3eba24">

To follow this Zeplin UI we need to [globally override how controls are created](https://docs.mapbox.com/mapbox-gl-js/api/markers/#icontrol) which can be time consuming. @benoitFortune I can create a Story to keep track a potential evolution. 

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
