### PR TITLE
chore(CI): update github actions

### DIFF
--- a/.github/workflows/api-client.yml
+++ b/.github/workflows/api-client.yml
@@ -1,8 +1,11 @@
 name: api-client coverage
 on:
-  push:
+  pull_request:
     paths:
     - 'packages/api-client/**'
+  push:
+    branches:
+      - main
 jobs:
   build:
     name: Get api client test coverage on node ${{ matrix.node }} and ${{ matrix.os }}

--- a/.github/workflows/visualizations.yml
+++ b/.github/workflows/visualizations.yml
@@ -1,6 +1,9 @@
 name: "Visualizations"
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened
@@ -66,7 +69,7 @@ jobs:
         run: npm run lint
 
   chromatic-deployment:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false || github.ref_name == 'main'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Last two commits in the main branch has no CI (https://github.com/opendatasoft/ods-dataviz-sdk/commits/main/).
 The goal for this PR is to make Github actions run again on `main` branch

(Internal for Opendatasoft only) Associated Shortcut ticket: 🏴‍☠️ 

### Changes

Update workflows triggers



## To be tested

_points that may not be obviously related to the changes but are impacted_

_special cases that are not widely known_

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
