### PR TITLE
fix(POI Maps): prevent change in sort order for symbol features

### DIFF
--- a/packages/visualizations/src/components/MapPoi/Map.ts
+++ b/packages/visualizations/src/components/MapPoi/Map.ts
@@ -28,6 +28,7 @@ import {
     POPUP_OPTIONS,
     POPUP_WIDTH,
     POPUP_NAVIGATION_CONTROLS_OFFSET_CLASSNAME,
+    DEFAULT_SORT_KEY_VALUE,
 } from './constants';
 import type {
     PopupConfigurationByLayers,
@@ -61,7 +62,7 @@ const sortLayerFeatures = (
 
 /** Restores the original sorting order of features in a layer */
 const unsortLayerFeatures = (map: Map, layer: MapGeoJSONFeature['layer']) => {
-    map.setLayoutProperty(layer.id, `${layer.type}-sort-key`, 0);
+    map.setLayoutProperty(layer.id, `${layer.type}-sort-key`, DEFAULT_SORT_KEY_VALUE);
 };
 
 type MapFunction = (map: Map) => unknown;

--- a/packages/visualizations/src/components/MapPoi/constants.ts
+++ b/packages/visualizations/src/components/MapPoi/constants.ts
@@ -1,4 +1,9 @@
-import type { ControlPosition, PopupOptions, StyleSpecification } from 'maplibre-gl';
+import type {
+    ControlPosition,
+    DataDrivenPropertyValueSpecification,
+    PopupOptions,
+    StyleSpecification,
+} from 'maplibre-gl';
 import type { Color } from '../types';
 import { POPUP_DISPLAY, PopupDisplayTypes } from './types';
 
@@ -12,6 +17,13 @@ export const DEFAULT_BASEMAP_STYLE: StyleSpecification = {
 export const DEFAULT_ASPECT_RATIO = 1;
 
 export const DEFAULT_DARK_GREY: Color = '#515457';
+
+export const DEFAULT_SORT_KEY_VALUE: DataDrivenPropertyValueSpecification<number> = [
+    'case',
+    ['==', ['id'], ''],
+    0,
+    0,
+];
 
 export const POPUP_WIDTH = 300;
 

--- a/packages/visualizations/src/components/MapPoi/utils.ts
+++ b/packages/visualizations/src/components/MapPoi/utils.ts
@@ -20,7 +20,12 @@ import type {
     PopupConfigurationByLayers,
     SymbolLayer,
 } from './types';
-import { DEFAULT_DARK_GREY, DEFAULT_BASEMAP_STYLE, DEFAULT_ASPECT_RATIO } from './constants';
+import {
+    DEFAULT_DARK_GREY,
+    DEFAULT_BASEMAP_STYLE,
+    DEFAULT_ASPECT_RATIO,
+    DEFAULT_SORT_KEY_VALUE,
+} from './constants';
 
 export const getMapStyle = (style: PoiMapOptions['style']): MapOptions['style'] => {
     if (!style) return DEFAULT_BASEMAP_STYLE;
@@ -122,6 +127,7 @@ const getMapSymbolLayer = (layer: SymbolLayer): SymbolLayerSpecification => {
             'icon-size': 1,
             'icon-allow-overlap': true,
             'icon-image': iconImage,
+            'symbol-sort-key': DEFAULT_SORT_KEY_VALUE,
         },
     };
 };


### PR DESCRIPTION
## Summary

The goal for this PR is to prevent features in symbol layer to change of sort order. This result in a visual glitch where symbol feature change sort order when a feature is active (clicked)

Once we set a expression for the 'symbol-sort-key' property we need to reset the same expression. Otherwise sort order will change once the popup is removed. 

(Internal for Opendatasoft only) Associated Shortcut ticket: 🏴‍☠️ 

## To be tested

Link to the platform and create POI Maps with a large number of symbol

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
