### PR TITLE
feat: sorted, sortable, styled stories

### DIFF
--- a/packages/visualizations-react/src/components/Table.tsx
+++ b/packages/visualizations-react/src/components/Table.tsx
@@ -1,0 +1,8 @@
+import { Table as _Table, TableOptions, DataFrame } from '@opendatasoft/visualizations';
+import { FC } from 'react';
+import { Props } from './Props';
+import wrap from './ReactImpl';
+
+// Explicit name and type are needed for storybook
+const Chart: FC<Props<DataFrame, TableOptions>> = wrap(_Table);
+export default Chart;

--- a/packages/visualizations-react/src/index.tsx
+++ b/packages/visualizations-react/src/index.tsx
@@ -6,3 +6,4 @@ export { default as ChoroplethGeoJson } from './components/ChoroplethGeoJson';
 export { default as ChoroplethVectorTiles } from './components/ChoroplethVectorTiles';
 export { default as ChoroplethSvg } from './components/ChoroplethSvg';
 export { default as PoiMap } from './components/PoiMap';
+export { default as Table } from './components/Table';

--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -76,14 +76,14 @@ const fixedColumns: Column[] = [
         key: 'name',
         format: string => `<span>${string}</span>`,
         width: 200,
-        fixed: true,
+        fixed: 'left',
     },
     {
         title: 'Address',
         key: 'address',
         format: string => `<span>${string}</span>`,
         width: 200,
-        fixed: true,
+        fixed: 'left',
     },
     {
         title: 'Number',
@@ -108,7 +108,7 @@ const sortableColumns: Column[] = [
         key: 'address',
         format: string => `<span>${string}</span>`,
         sort: {
-            onSort: sortName,
+            onSort: sortAddress,
             label: 'sort by length'
         }
     },
@@ -153,14 +153,6 @@ DefaultSorted.args = {
 } as Props<DataFrame, TableOptions>;
 
 export const Sortable = Template.bind({});
-Sortable.args = {
-    data,
-    options: {
-        columns: sortableColumns,
-    },
-} as Props<DataFrame, TableOptions>;
-
-export const SortAriaButton = Template.bind({});
 Sortable.args = {
     data,
     options: {

--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { DataFrame, Column, TableOptions, Async } from '@opendatasoft/visualizations';
+import { DataFrame, Column, TableOptions, Async, DATA_FORMATS } from '@opendatasoft/visualizations';
 import { Table } from '../../src';
 import type { Props } from '../../src';
 
@@ -56,17 +56,18 @@ const columns: Column[] = [
     {
         title: 'Name',
         key: 'name',
-        format: string => `<span>${string}</span>`,
+        dataFormat: DATA_FORMATS.shortText,
     },
     {
         title: 'Address',
         key: 'address',
-        format: string => `<span>${string}</span>`,
+        dataFormat: DATA_FORMATS.longText,
+
     },
     {
         title: 'Number',
         key: 'number',
-        format: number => `<span>${number}</span>`,
+        dataFormat: DATA_FORMATS.integer,
     },
 ];
 
@@ -74,48 +75,22 @@ const fixedColumns: Column[] = [
     {
         title: 'Name',
         key: 'name',
-        format: string => `<span>${string}</span>`,
+        dataFormat: DATA_FORMATS.shortText,
         width: 200,
         fixed: 'left',
     },
     {
         title: 'Address',
         key: 'address',
-        format: string => `<span>${string}</span>`,
+        dataFormat: DATA_FORMATS.longText,
         width: 200,
         fixed: 'left',
     },
     {
         title: 'Number',
         key: 'number',
-        format: number => `<span style="text-align: right;">${number}</span>`,
+        dataFormat: DATA_FORMATS.integer,
         width: 1000,
-    },
-];
-
-const sortableColumns: Column[] = [
-    {
-        title: 'Name',
-        key: 'name',
-        format: string => `<span>${string}</span>`,
-        sort: {
-            onSort: sortName,
-            label: 'sort alphabetically'
-        }
-    },
-    {
-        title: 'Address',
-        key: 'address',
-        format: string => `<span>${string}</span>`,
-        sort: {
-            onSort: sortAddress,
-            label: 'sort by length'
-        }
-    },
-    {
-        title: 'Number',
-        key: 'number',
-        format: number => `<span>${number}</span>`,
     },
 ];
 

--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { DataFrame, Column , TableOptions } from "@opendatasoft/visualizations";
+import { Table } from '../../src';
+import type { Props } from "../../src";
+
+import './my-class.css';
+
+const meta: ComponentMeta<typeof Table> = {
+    title: 'table',
+};
+export default meta;
+
+const value: DataFrame = [
+    {
+        name: 'Mohn',
+        address: 'New York',
+        number: 10,
+    },
+    {
+        name: 'Kohn',
+        address: '1 street New York',
+        number: 10,
+    },
+    {
+        name: 'John',
+        address: '1 street 789000 NewYork',
+        number: 10,
+    },
+    {
+        name: 'Lohn',
+        address: '1 street 789000 NewYork USofA',
+        number: 10,
+    },
+];
+
+const data = {
+    value,
+    isLoading: false,
+};
+
+const sortName = (a: any, b: any) => (a.name < b.name) ? -1 : 1;
+const sortAddress = (a: any, b: any) => a.address.length - b.address.length;
+
+const columns: Column[] = [
+    {
+        title: 'Name',
+        key: 'name',
+        format: string => `<span>${string}</span>`,
+    },
+    {
+        title: 'Address',
+        key: 'address',
+        format: string => `<span>${string}</span>`,
+    },
+    {
+        title: 'Number',
+        key: 'number',
+        format: number => `<span>${number}</span>`,
+    },
+];
+const sortableColumns: Column[] = [
+    {
+        title: 'Name',
+        key: 'name',
+        format: string => `<span>${string}</span>`,
+        onSort: sortName,
+    },
+    {
+        title: 'Address',
+        key: 'address',
+        format: string => `<span>${string}</span>`,
+        onSort: sortAddress,
+    },
+    {
+        title: 'Number',
+        key: 'number',
+        format: number => `<span>${number}</span>`,
+    },
+];
+
+const buildTemplate = (className?: string) => {
+    const Template: ComponentStory<typeof Table> = args => (
+    <div className={className}>
+        <Table {...args} />
+    </div>
+    );
+    return Template;
+};
+const Template = buildTemplate();
+const StyledTemplate = buildTemplate('myClass');
+
+export const Default = Template.bind({});
+Default.args = {
+    data,
+    options: {
+        columns,
+        pages: {
+            current: 1,
+            total: 1,
+            setPage: () => {},
+        }
+    }
+} as Props<DataFrame, TableOptions>;
+
+export const DefaultSorted = Template.bind({});
+DefaultSorted.args = {
+    data,
+    options: {
+        columns,
+        defaultSortKey: 'name',
+        pages: {
+            current: 1,
+            total: 1,
+            setPage: () => {},
+        }
+    }
+} as Props<DataFrame, TableOptions>;
+
+export const Sortable = Template.bind({});
+Sortable.args = {
+    data,
+    options: {
+        columns: sortableColumns,
+        defaultSort: 'name',
+        pages: {
+            current: 1,
+            total: 1,
+            setPage: () => {},
+        }
+    }
+} as Props<DataFrame, TableOptions>;
+
+export const Styled = StyledTemplate.bind({});
+Styled.args = {
+    data,
+    options: {
+        columns,
+        pages: {
+            current: 1,
+            total: 1,
+            setPage: () => {},
+        }
+    }
+};

--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -98,13 +98,19 @@ const sortableColumns: Column[] = [
         title: 'Name',
         key: 'name',
         format: string => `<span>${string}</span>`,
-        onSort: sortName,
+        sort: {
+            onSort: sortName,
+            label: 'sort alphabetically'
+        }
     },
     {
         title: 'Address',
         key: 'address',
         format: string => `<span>${string}</span>`,
-        onSort: sortAddress,
+        sort: {
+            onSort: sortName,
+            label: 'sort by length'
+        }
     },
     {
         title: 'Number',
@@ -147,6 +153,14 @@ DefaultSorted.args = {
 } as Props<DataFrame, TableOptions>;
 
 export const Sortable = Template.bind({});
+Sortable.args = {
+    data,
+    options: {
+        columns: sortableColumns,
+    },
+} as Props<DataFrame, TableOptions>;
+
+export const SortAriaButton = Template.bind({});
 Sortable.args = {
     data,
     options: {

--- a/packages/visualizations-react/stories/Table/my-class.css
+++ b/packages/visualizations-react/stories/Table/my-class.css
@@ -1,0 +1,16 @@
+.myClass {
+    table {
+        border: 1px solid black;
+        border-radius: 3px;
+    }
+
+    th {
+        border: 2px solid;
+        background: blue;
+    }
+
+    tr {
+        background: lightgrey;
+        border-bottom: 1px solidy;
+    }
+}

--- a/packages/visualizations/src/components/Table/Body.svelte
+++ b/packages/visualizations/src/components/Table/Body.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    import type { Column } from './types';
+    import Cell from './Cell.svelte';
+    import { columnOffset } from './utils';
+    import type { DataFrame } from '../types';
+
+    export let columns: Column[];
+    export let records: DataFrame;
+</script>
+
+<tbody>
+    {#each records as record}
+        <tr>
+            {#each columns as column, i}
+                <Cell {column} {record} offset={columnOffset(columns, i)} />
+            {/each}
+        </tr>
+    {/each}
+</tbody>

--- a/packages/visualizations/src/components/Table/Cell.svelte
+++ b/packages/visualizations/src/components/Table/Cell.svelte
@@ -1,19 +1,24 @@
 <script lang="ts">
     import type { Column } from './types';
-    import { formatCell } from './utils';
+    import { format } from './utils';
 
     export let column: Column;
     export let record: Record<string, unknown>;
     export let offset: number | undefined;
+    
+    $: ({ cellStyle, dataFormat, fixed } = column);
+    $: ( { formatCell, formatRecord = (v: any) => v } =  format[column.dataFormat]);
 </script>
 
 <td
     style="
-        position: {column.fixed ? 'sticky' : ''}; 
-        left: {column.fixed ? offset : ''}px;
+        position: {fixed ? 'sticky' : ''}; 
+        left: {fixed ? offset : ''}px;
+        {formatCell(dataFormat)}
+        {cellStyle && cellStyle(record).cssText};
     "
 >
-    {@html formatCell(column, record)}
+    {formatRecord(record[column.key])}
 </td>
 
 <style>

--- a/packages/visualizations/src/components/Table/Cell.svelte
+++ b/packages/visualizations/src/components/Table/Cell.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+    import type { Column } from './types';
+    import { formatCell } from './utils';
+
+    export let column: Column;
+    export let record: Record<string, unknown>;
+    export let offset: number | undefined;
+</script>
+
+<td
+    style="
+        position: {column.fixed ? 'sticky' : ''}; 
+        left: {column.fixed ? offset : ''}px;
+    "
+>
+    {@html formatCell(column, record)}
+</td>
+
+<style>
+    td {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+</style>

--- a/packages/visualizations/src/components/Table/ColGroup.svelte
+++ b/packages/visualizations/src/components/Table/ColGroup.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    import type { Column } from './types';
+
+    export let columns: Column[];
+</script>
+
+<colgroup>
+    {#each columns as column}
+        <col style="width: {column.width || 'auto'}px;">
+    {/each}
+</colgroup>
+
+<style>
+</style>

--- a/packages/visualizations/src/components/Table/Header.svelte
+++ b/packages/visualizations/src/components/Table/Header.svelte
@@ -1,27 +1,32 @@
 <script lang="ts">
-    import type { Column, ColumnSorter } from './types';
+    import { assertUnreachable } from '../utils';
+    import type { Column, ColumnSorter, Order, SortKey } from './types';
     import { columnOffset } from './utils';
 
     export let columns: Column[];
     export let fixed: boolean | undefined;
-    export let sortRecords: ((onSort: ColumnSorter) => void)| undefined;
-    export let defaultSortKey: string | undefined;
+    export let defaultSortKey: SortKey | undefined;
     
-    let sortedCol = {
-        key: defaultSortKey || null,
-        ascending: true,
+    let sortedCol = defaultSortKey;
+
+    const nextOrder = (order?: Order) => {
+        switch(order) {
+            case null: return 'desc';
+            case 'desc': return 'asc';
+            case 'asc': return null;
+            default: return 'asc';
+        }
     };
-
     const sortColumn = (column: Column) => {
-        if (!sortRecords || !column?.sort) return;
+        if (!column?.sort) return;
 
-        const isSorted = sortedCol.key === column.key;
         const { onSort } = column.sort;
+        onSort();
+
         sortedCol = {
             key: column.key,
-            ascending: isSorted ? !sortedCol.ascending : true,
-        };
-        sortRecords(onSort);
+            order: nextOrder(sortedCol?.order)
+        };         
     };
     
 </script>

--- a/packages/visualizations/src/components/Table/Header.svelte
+++ b/packages/visualizations/src/components/Table/Header.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+    import type { Column, ColumnSorter } from './types';
+    import { columnOffset } from './utils';
+
+    export let columns: Column[];
+    export let fixed: boolean | undefined;
+    export let sortRecords: ((onSort: ColumnSorter) => void)| undefined;
+    export let defaultSortKey: string | undefined;
+    
+    let sortedCol = {
+        key: defaultSortKey || null,
+        ascending: true,
+    };
+
+    const sortColumn = (column: Column) => {
+        if (!sortRecords || !column?.sort) return;
+
+        const isSorted = sortedCol.key === column.key;
+        const { onSort } = column.sort;
+        sortedCol = {
+            key: column.key,
+            ascending: isSorted ? !sortedCol.ascending : true,
+        };
+        sortRecords(onSort);
+    };
+    
+</script>
+
+<thead class:fixed>
+    <tr>
+        {#each columns as column, i}
+            <th style="position: {column.fixed ? 'sticky' : ''}; left: {column.fixed ? columnOffset(columns, i): ''}px;">
+                {column.title}
+                {#if column?.sort}
+                    <button 
+                        on:click={() => sortColumn(column)}
+                        aria-label={column.sort.label}
+                    >
+                        sort
+                    </button>
+                {/if}
+            </th>
+        {/each}
+    </tr>
+</thead>
+
+<style>
+    th {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    thead.fixed {
+        /* Nice implem' 😎 */
+        position: sticky;
+        top: 0;
+    }
+
+    th,
+
+
+    :global(.defaultStyle) th {
+        padding: 13px;
+        background: white;
+        border-bottom: 1px solid lightgray;
+    }
+</style>

--- a/packages/visualizations/src/components/Table/Pagination.svelte
+++ b/packages/visualizations/src/components/Table/Pagination.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+    import type { TableOptions } from "./types";
+
+    export let setPage: Required<TableOptions>['pages']['setPage'];
+    export let current: number;
+    export let total: number;
+
+    $: pagination = Array.from({length: total - 1}, (_, i) => i + 2);
+</script>
+
+<ul>
+    <li on:click={() => setPage(current - 1)}>
+        <button>{'<<'}</button>
+    </li>
+    {#each pagination as page}
+        <li on:click={() => setPage(page)}>{page}</li>
+    {/each}
+    <li on:click={() => setPage(current + 1)}>
+        <button>{'>>'}</button>
+    </li>
+</ul>
+
+<style>
+    ul {
+        display: flex;
+        list-style: none;
+    }
+</style>
+
+<!-- markup (zero or more items) goes here -->

--- a/packages/visualizations/src/components/Table/Pagination.svelte
+++ b/packages/visualizations/src/components/Table/Pagination.svelte
@@ -2,20 +2,31 @@
     import type { TableOptions } from "./types";
 
     export let setPage: Required<TableOptions>['pages']['setPage'];
-    export let current: number;
+    export let initial: number;
     export let total: number;
+    
+    let current = initial;
+    const changePage = (page: number) => {
+        setPage(page);
+        current = page;
+    };
 
-    $: pagination = Array.from({length: total - 1}, (_, i) => i + 2);
+    $: pages = [...Array(total).keys()];
 </script>
 
 <ul>
-    <li on:click={() => setPage(current - 1)}>
+    <li on:click={() => changePage(current - 1)}>
         <button>{'<<'}</button>
     </li>
-    {#each pagination as page}
-        <li on:click={() => setPage(page)}>{page}</li>
+    {#each pages as page}
+        <li 
+            on:click={() => changePage(page)}
+            class:current={page === current}
+        >
+            {page}
+        </li>
     {/each}
-    <li on:click={() => setPage(current + 1)}>
+    <li on:click={() => changePage(current + 1)}>
         <button>{'>>'}</button>
     </li>
 </ul>
@@ -24,6 +35,17 @@
     ul {
         display: flex;
         list-style: none;
+    }
+
+    li {
+        cursor: pointer;
+        margin-left: 6px;
+    }
+
+    .current {
+        color: red;
+        border: 1px solid;
+        padding: 3px;
     }
 </style>
 

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -25,7 +25,6 @@
             sorted = key;
         }
     };
-    $: console.log(defaultSortKey, sorted);
     
 </script>
 
@@ -74,6 +73,12 @@
     th, td {
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    .defaultStyle th {
+        padding: 13px;
+        background: white;
+        border-bottom: 1px solid lightgray;
     }
 
     thead.fixedHeader {

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -4,6 +4,9 @@
     import type { Column, TableOptions } from './types';
     import type { Async } from '../../types';
     import Pagination from './Pagination.svelte';
+    import ColGroup from './ColGroup.svelte';
+    import Header from './Header.svelte';
+    import Body from './Body.svelte';
 
     export let data: Async<DataFrame>;
     export let options: TableOptions;
@@ -11,65 +14,29 @@
     $: ({ value: records } = data);
     $: ({ unstyled = false, columns, pages, fixedHeader, defaultSortKey } = options);
     $: defaultStyle = !unstyled;
-    $: sorted = defaultSortKey;
 
-    const format = (column: Column, record: Record<string, unknown>) => {
-        if (typeof column?.format === 'function') {
-            return column.format(record[column.key]);
-        }
-        return record[column.key];
-    };
-
-    const reOrder = (onSort: Required<Column>['onSort'], key: string) => {
+    const sortRecords = (onSort: Required<Column>['sort']['onSort']) => {
         if (records?.sort) {
             records = [...records.sort(onSort)];
-            sorted = key;
         }
     };
-
-    const columnOffSet = (cols: Column[], index: number) => sumBy(cols.slice(0, index), col => col.width || 0);
 </script>
 
 <div class="scroll-container">
-    <table class:defaultStyle style="width: {sumBy(columns, col => col?.width || 0)}px;">
-        <colgroup>
-            {#each columns as column}
-                <col style="width: {column.width}px;">
-            {/each}
-        </colgroup>
-        <thead class:fixedHeader>
-            <tr>
-                {#each columns as column, i}
-                    <th style="position: {column.fixed ? 'sticky' : ''}; left: {column.fixed ? columnOffSet(columns, i): ''}px;">
-                        {column.title}
-                        {#if column?.sort}
-                            <button 
-                                on:click={() => reOrder(column.sort.onSort, column.key)}
-                                aria-label={column.sort.label}
-                            >
-                                sort
-                            </button>
-                        {/if}
-                        {#if sorted === column.key}
-                            <span>I'm sorted</span>
-                        {/if}
-                    </th>
-                {/each}
-            </tr>
-        </thead>
-        <tbody>
-            {#if records}
-                {#each records as record}
-                    <tr>
-                        {#each columns as column, i}
-                            <td style="position: {column.fixed ? 'sticky' : ''}; left: { column.fixed ? columnOffSet(columns, i): ''}px;">
-                                {@html format(column, record)}
-                            </td>
-                        {/each}
-                    </tr>
-                {/each}
-            {/if}
-        </tbody>
+    <table class:defaultStyle style="width: {sumBy(columns, (col) => col?.width || 0)}px;">
+        <ColGroup {columns} />
+        <Header 
+            {columns}
+            {sortRecords}
+            {defaultSortKey}
+            fixed={fixedHeader}
+        />
+        {#if records}
+            <Body
+                {records}
+                {columns}
+            />           <!-- content here -->
+        {/if}
         {#if pages}
             <Pagination {...pages} />
         {/if}
@@ -87,23 +54,5 @@
     }
     table.defaultStyle {
         border: 2px solid black;
-    }
-
-    th,
-    td {
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-
-    .defaultStyle th {
-        padding: 13px;
-        background: white;
-        border-bottom: 1px solid lightgray;
-    }
-
-    thead.fixedHeader {
-        /* Nice implem' 😎 */
-        position: sticky;
-        top: 0;
     }
 </style>

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+    import type { DataFrame } from '../types';
+    import type { Column, TableOptions } from './types';
+    import type { Async } from '../../types';
+    import Pagination from './Pagination.svelte';
+
+    export let data: Async<DataFrame>;
+    export let options: TableOptions;
+
+    $: ({ value: records } = data);
+    $: ({ unstyled = false, columns, pages, fixedHeader, defaultSortKey } = options);
+    $: defaultStyle = !unstyled;
+    $: sorted = defaultSortKey;
+    
+    const format = (column: Column, record: Record<string, unknown>) => {
+        if (typeof column?.format === 'function') {
+            return column.format(record[column.key]);
+        }
+        return record[column.key];
+    };
+
+    const reOrder = (onSort: Required<Column>['onSort'], key: string) => {
+        if (records?.sort) {
+            records = [...records.sort(onSort)];
+            sorted = key;
+        }
+    };
+    $: console.log(defaultSortKey, sorted);
+    
+</script>
+
+<table class:defaultStyle>
+    <colgroup>
+        {#each columns as _}
+            <col>
+        {/each}
+    </colgroup>
+    <thead class:fixedHeader>
+        <tr>
+            {#each columns as column}
+                <th>
+                    {column.title}
+                    {#if column?.onSort}
+                        <button on:click={() => reOrder(column.onSort, column.key)}>sort</button>
+                    {/if}
+                    {#if sorted === column.key}
+                    <span>I'm sorted</span>
+                    {/if}
+                </th>
+            {/each}
+        </tr>
+    </thead>
+    <tbody>
+        {#if records}
+            {#each records as record}
+                <tr>
+                    {#each columns as column}
+                        <td>{@html format(column, record)}</td>
+                    {/each}
+                </tr>
+            {/each}
+        {/if}
+    </tbody>
+    {#if pages}
+        <Pagination {...pages} />
+    {/if}
+</table>
+
+<style>
+    table.defaultStyle {
+        border: 2px solid black;
+    }
+
+    th, td {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    thead.fixedHeader {
+        /* Nice implem' 😎 */
+        position: sticky;
+        top: 0;
+    }
+
+    col {
+        width: 200px;
+    }
+</style>

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { sum, sumBy } from 'lodash';
     import type { DataFrame } from '../types';
     import type { Column, TableOptions } from './types';
     import type { Async } from '../../types';
@@ -11,7 +12,7 @@
     $: ({ unstyled = false, columns, pages, fixedHeader, defaultSortKey } = options);
     $: defaultStyle = !unstyled;
     $: sorted = defaultSortKey;
-    
+
     const format = (column: Column, record: Record<string, unknown>) => {
         if (typeof column?.format === 'function') {
             return column.format(record[column.key]);
@@ -25,52 +26,67 @@
             sorted = key;
         }
     };
-    
+
+    const columnOffSet = (cols: Column[], index: number) => {
+        return sumBy(cols.slice(0, index), col => col.width || 0);
+    };
 </script>
 
-<table class:defaultStyle>
-    <colgroup>
-        {#each columns as _}
-            <col>
-        {/each}
-    </colgroup>
-    <thead class:fixedHeader>
-        <tr>
+<div class="scroll-container">
+    <table class:defaultStyle style="width: 1400px;">
+        <colgroup>
             {#each columns as column}
-                <th>
-                    {column.title}
-                    {#if column?.onSort}
-                        <button on:click={() => reOrder(column.onSort, column.key)}>sort</button>
-                    {/if}
-                    {#if sorted === column.key}
-                    <span>I'm sorted</span>
-                    {/if}
-                </th>
+                <col style="width: {column.width}px;">
             {/each}
-        </tr>
-    </thead>
-    <tbody>
-        {#if records}
-            {#each records as record}
-                <tr>
-                    {#each columns as column}
-                        <td>{@html format(column, record)}</td>
-                    {/each}
-                </tr>
-            {/each}
+        </colgroup>
+        <thead class:fixedHeader>
+            <tr>
+                {#each columns as column, i}
+                    <th style="position: {column.fixed ? 'sticky' : ''}; left: {column.fixed ? columnOffSet(columns, i): ''}px;">
+                        {column.title}
+                        {#if column?.onSort}
+                            <button on:click={() => reOrder(column.onSort, column.key)}>sort</button>
+                        {/if}
+                        {#if sorted === column.key}
+                            <span>I'm sorted</span>
+                        {/if}
+                    </th>
+                {/each}
+            </tr>
+        </thead>
+        <tbody>
+            {#if records}
+                {#each records as record}
+                    <tr>
+                        {#each columns as column, i}
+                            <td style="position: {column.fixed ? 'sticky' : ''}; left: { column.fixed ? columnOffSet(columns, i): ''}px;">
+                                {@html format(column, record)}
+                            </td>
+                        {/each}
+                    </tr>
+                {/each}
+            {/if}
+        </tbody>
+        {#if pages}
+            <Pagination {...pages} />
         {/if}
-    </tbody>
-    {#if pages}
-        <Pagination {...pages} />
-    {/if}
-</table>
+    </table>
+</div>
 
 <style>
+    .scroll-container {
+        width: 100%;
+        overflow: auto hidden;
+    }
+    table {
+        table-layout: fixed;
+    }
     table.defaultStyle {
         border: 2px solid black;
     }
 
-    th, td {
+    th,
+    td {
         overflow: hidden;
         text-overflow: ellipsis;
     }
@@ -85,9 +101,5 @@
         /* Nice implem' 😎 */
         position: sticky;
         top: 0;
-    }
-
-    col {
-        width: 200px;
     }
 </style>

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { sum, sumBy } from 'lodash';
+    import { sumBy } from 'lodash';
     import type { DataFrame } from '../types';
     import type { Column, TableOptions } from './types';
     import type { Async } from '../../types';
@@ -27,13 +27,11 @@
         }
     };
 
-    const columnOffSet = (cols: Column[], index: number) => {
-        return sumBy(cols.slice(0, index), col => col.width || 0);
-    };
+    const columnOffSet = (cols: Column[], index: number) => sumBy(cols.slice(0, index), col => col.width || 0);
 </script>
 
 <div class="scroll-container">
-    <table class:defaultStyle style="width: 1400px;">
+    <table class:defaultStyle style="width: {sumBy(columns, col => col?.width || 0)}px;">
         <colgroup>
             {#each columns as column}
                 <col style="width: {column.width}px;">
@@ -44,8 +42,13 @@
                 {#each columns as column, i}
                     <th style="position: {column.fixed ? 'sticky' : ''}; left: {column.fixed ? columnOffSet(columns, i): ''}px;">
                         {column.title}
-                        {#if column?.onSort}
-                            <button on:click={() => reOrder(column.onSort, column.key)}>sort</button>
+                        {#if column?.sort}
+                            <button 
+                                on:click={() => reOrder(column.sort.onSort, column.key)}
+                                aria-label={column.sort.label}
+                            >
+                                sort
+                            </button>
                         {/if}
                         {#if sorted === column.key}
                             <span>I'm sorted</span>
@@ -79,6 +82,7 @@
         overflow: auto hidden;
     }
     table {
+        min-width: 100%;
         table-layout: fixed;
     }
     table.defaultStyle {

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -12,14 +12,15 @@
     export let options: TableOptions;
 
     $: ({ value: records } = data);
-    $: ({ unstyled = false, columns, pages, fixedHeader, defaultSortKey } = options);
+    $: ({ 
+            unstyled = false,
+            columns,
+            pages,
+            fixedHeader = true,
+            size = 'medium',
+            defaultSortKey
+        } = options);
     $: defaultStyle = !unstyled;
-
-    const sortRecords = (onSort: Required<Column>['sort']['onSort']) => {
-        if (records?.sort) {
-            records = [...records.sort(onSort)];
-        }
-    };
 </script>
 
 <div class="scroll-container">
@@ -27,7 +28,6 @@
         <ColGroup {columns} />
         <Header 
             {columns}
-            {sortRecords}
             {defaultSortKey}
             fixed={fixedHeader}
         />

--- a/packages/visualizations/src/components/Table/index.ts
+++ b/packages/visualizations/src/components/Table/index.ts
@@ -1,0 +1,10 @@
+import SvelteImpl from '../SvelteImpl';
+import type { DataFrame } from '../types';
+import TableImpl from './Table.svelte';
+import type { TableOptions  } from './types';
+
+export default class Table extends SvelteImpl<DataFrame, TableOptions> {
+    protected getSvelteComponentClass(): typeof TableImpl {
+        return TableImpl;
+    }
+}

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -1,5 +1,3 @@
-import type { DataFrame } from "../types";
-
 export const DataType = {
     'long-text': 'long-text',
     'short-text': 'short-text',
@@ -27,7 +25,7 @@ export type TableOptions = {
     unstyled?: boolean;
     defaultSortKey?: string;
     pages?: {
-        current: number;
+        initial: number;
         total: number;
         setPage: (next: number) => void;
     }

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -15,6 +15,7 @@ export type Column = {
     /** how to render the data. Outputs an HTML string */
     format?: SupportedDataTypes | ((datum: unknown) => string);
     fixed?: boolean;
+    width?: number;
     /** To be passed to an Array.sort */
     onSort?: (a: Record<string, unknown>, b: Record<string, unknown>) => number;
 };

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -1,0 +1,34 @@
+import type { DataFrame } from "../types";
+
+export const DataType = {
+    'long-text': 'long-text',
+    'short-text': 'short-text',
+    date: 'date',
+    integer: 'integer',
+    float: 'float',
+} as const;
+
+export type SupportedDataTypes = keyof typeof DataType;
+
+export type Column = {
+    title: string;
+    /** key name in the data object */
+    key: string;
+    /** how to render the data. Outputs an HTML string */
+    format?: SupportedDataTypes | ((datum: unknown) => string);
+    fixed?: boolean;
+    /** To be passed to an Array.sort */
+    onSort?: (a: Record<string, unknown>, b: Record<string, unknown>) => number;
+};
+
+export type TableOptions = {
+    fixedHeader?: boolean;
+    columns: Column[];
+    unstyled?: boolean;
+    defaultSortKey?: string;
+    pages?: {
+        current: number;
+        total: number;
+        setPage: (next: number) => void;
+    }
+};

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -14,10 +14,13 @@ export type Column = {
     key: string;
     /** how to render the data. Outputs an HTML string */
     format?: SupportedDataTypes | ((datum: unknown) => string);
-    fixed?: boolean;
+    fixed?: 'left' | 'right';
     width?: number;
     /** To be passed to an Array.sort */
-    onSort?: (a: Record<string, unknown>, b: Record<string, unknown>) => number;
+    sort?: {
+        onSort: (a: Record<string, unknown>, b: Record<string, unknown>) => number;
+        label: string;
+    }
 };
 
 export type TableOptions = {

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -7,7 +7,7 @@ export const DataType = {
 } as const;
 
 export type SupportedDataTypes = keyof typeof DataType;
-
+export type ColumnSorter = (a: Record<string, unknown>, b: Record<string, unknown>) => number;
 export type Column = {
     title: string;
     /** key name in the data object */
@@ -18,7 +18,7 @@ export type Column = {
     width?: number;
     /** To be passed to an Array.sort */
     sort?: {
-        onSort: (a: Record<string, unknown>, b: Record<string, unknown>) => number;
+        onSort: ColumnSorter;
         label: string;
     }
 };

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -1,36 +1,90 @@
-export const DataType = {
-    'long-text': 'long-text',
-    'short-text': 'short-text',
+export const DATA_FORMATS = {
+    longText: 'long-text',
+    shortText: 'short-text',
     date: 'date',
     integer: 'integer',
     float: 'float',
 } as const;
 
-export type SupportedDataTypes = keyof typeof DataType;
-export type ColumnSorter = (a: Record<string, unknown>, b: Record<string, unknown>) => number;
-export type Column = {
-    title: string;
-    /** key name in the data object */
+export type SupportedDataKeys = keyof typeof DATA_FORMATS;
+export type SupportedDataFormat = typeof DATA_FORMATS[SupportedDataKeys];
+
+export type Size = 'large' | 'medium' | 'small';
+export type Order = 'asc' | 'desc' | null;
+export type Dir = 'ltr' | 'rtl';
+export type Fixed = 'start' | 'end';
+export type SortKey = {
     key: string;
-    /** how to render the data. Outputs an HTML string */
-    format?: SupportedDataTypes | ((datum: unknown) => string);
-    fixed?: 'left' | 'right';
+    order: Order;
+};
+
+export type Column = {
+     /** Mandatory */
+    title: string;
+     /** Mandatory
+    /* key name in the data object */
+    key: string;
+    /** Real functions to be implemented in beta (further stories)
+     * how to render the data. Outputs an HTML string */
+    dataFormat: SupportedDataFormat;
+    /** To be implemented in beta */
+    cellStyle?: (datum: unknown) => CSSStyleDeclaration;
+    /** To be implemented in beta */
+    fixed?: Fixed;
+    /** To be implemented in beta (auto or fixed?) */
     width?: number;
-    /** To be passed to an Array.sort */
+    /** To be implemented later */
+    dir?: Dir;
+    /** To be implemented later */
+    footer?: { // To display an information as a footer column
+        label: string; // Is a sum, a mean, etc...
+        value: SupportedDataFormat;
+    }
+    /** To be implemented in beta? */
     sort?: {
-        onSort: ColumnSorter;
-        label: string;
+        onSort: () => void;
+        position?: number;
     }
 };
 
 export type TableOptions = {
+    /** To be implemented in beta */
     fixedHeader?: boolean;
+    /** To be implemented later */
+    searchable: boolean;
+    /** Mandatory */
     columns: Column[];
+     /** To be implemented in beta */
     unstyled?: boolean;
-    defaultSortKey?: string;
+    /** To be implemented later */
+    dir?: Dir;
+    /** To be implemented later */
+    size: Size;
+    /** To be implemented in beta */
+    defaultSortKey?: {
+        key: string;
+        order: Order;
+    };
+    /** To be implemented in beta */
     pages?: {
+        position: 'top' | 'bottom' | 'both';
+        style: 'select' | 'buttons';
         initial: number;
-        total: number;
+        totalRecords: number;
+        recordsPerPage: number;
         setPage: (next: number) => void;
     }
+    /** Related to other Props, as fitting */
+    descriptions: {
+        sort: [{
+            asc: string;
+            desc: string;
+            clear: string;
+        }],
+        pagination: {
+            next: string;
+            previous: string;
+            goToPage?: string;
+        }
+    },
 };

--- a/packages/visualizations/src/components/Table/utils.ts
+++ b/packages/visualizations/src/components/Table/utils.ts
@@ -1,0 +1,11 @@
+import { sumBy } from 'lodash';
+import type { Column } from './types';
+
+export const columnOffset = (cols: Column[], index: number) => sumBy(cols.slice(0, index), col => col.width || 0);
+
+export const formatCell = (column: Column, record: Record<string, unknown>) => {
+    if (typeof column?.format === 'function') {
+        return column.format(record[column.key]);
+    }
+    return record[column.key];
+};

--- a/packages/visualizations/src/components/Table/utils.ts
+++ b/packages/visualizations/src/components/Table/utils.ts
@@ -1,11 +1,46 @@
 import { sumBy } from 'lodash';
-import type { Column } from './types';
+import { DATA_FORMATS, type Column, type SupportedDataFormat } from './types';
+import { assertUnreachable } from '../utils';
 
 export const columnOffset = (cols: Column[], index: number) => sumBy(cols.slice(0, index), col => col.width || 0);
 
-export const formatCell = (column: Column, record: Record<string, unknown>) => {
-    if (typeof column?.format === 'function') {
-        return column.format(record[column.key]);
+export const format = (dataFormat: SupportedDataFormat) => {
+    switch(dataFormat) {
+        case DATA_FORMATS.longText:
+            return {
+                formatCell: {
+                    textAlign: 'left',
+                    maxWidth: '300px',
+                    overflow: 'ellipsis',
+                    lineClamp: '3',
+                },
+            };
+        case DATA_FORMATS.shortText: 
+            return {
+                formatCell: {
+                    textAlign: 'left',
+                    maxWidth: '300px',
+                    overflow: 'ellipsis',
+                }
+            };
+        case DATA_FORMATS.integer:
+            return {
+                formatCell: {
+                    textAlign: 'right',    
+                }
+            };
+        case DATA_FORMATS.float:
+            return {
+                formatCell: {
+                    textAlign: 'right',
+                }
+            };
+        case DATA_FORMATS.date:
+            return {
+                formatCell: {
+                    textAlign: 'left',
+                }
+            };
+        default: return assertUnreachable(dataFormat);
     }
-    return record[column.key];
 };

--- a/packages/visualizations/src/index.ts
+++ b/packages/visualizations/src/index.ts
@@ -4,6 +4,7 @@ export { default as KpiCard } from './components/KpiCard';
 export { ChoroplethGeoJson, ChoroplethVectorTiles } from './components/Map/WebGl';
 export { default as ChoroplethSvg } from './components/Map/Svg';
 export { default as PoiMap } from './components/MapPoi';
+export { default as Table } from './components/Table';
 
 export * from './types';
 export * from './components/types';
@@ -13,3 +14,4 @@ export * from './components/Map/types';
 export * from './components/MarkdownText/types';
 export * from './components/MapPoi/types';
 export * from './components/Legend/types';
+export * from './components/Table/types';


### PR DESCRIPTION
## Summary

The goal for this PR is to to propose a props definition / API for the Table component. Most likely serve as the "main" PR for the table implem.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-46238](https://app.shortcut.com/opendatasoft/story/46238).

### Changes
Changes to review are mainly in `types.ts`, which is what we expose.

The `Table.svelte` is a base implementation just to check that we don't need extra props info etc. to implement the base details. Implem itself is pretty dirty as of now.

`Table.stories.tsx` is here to have a variety of test cases that our implem should fit. Potentially the place to add tests too.
