### PR TITLE
fix(style): import visualizations style in visualizations-react bundle

### DIFF
--- a/packages/visualizations-react/.storybook/preview.js
+++ b/packages/visualizations-react/.storybook/preview.js
@@ -1,2 +1,1 @@
-import '@opendatasoft/visualizations/dist/index.css';
 import './theme.css';

--- a/packages/visualizations-react/.storybook/theme.css
+++ b/packages/visualizations-react/.storybook/theme.css
@@ -17,22 +17,3 @@ h3 {
 a:link, a:visited, a:active {
     color: #774936;
 }
-
-/* Style for the Custom style Table story */
-.table-story--custom-style .table-wrapper {
-    border-color: #fcd4cf;
-}
-.table-story--custom-style thead {
-    border-bottom-color: #f94346;
-    border-bottom-width: 2px;
-    background-color: #fd635d;
-    color:#ffffff;
-}
-
-.table-story--custom-style tbody tr {
-    border-bottom-color: #fcd4cf;
-}
-.table-story--custom-style tbody tr:hover {
-    background-color: #f9aea4;
-}
-

--- a/packages/visualizations-react/jest.config.js
+++ b/packages/visualizations-react/jest.config.js
@@ -5,5 +5,7 @@ module.exports = {
     moduleNameMapper: {
         src: '<rootDir>/src',
         reactify: '<rootDir>/src/reactify',
+        // https://jestjs.io/docs/webpack#handling-static-assets
+        '\\.css$': '<rootDir>/test/__mocks__/styleMock.js',
     },
 };  

--- a/packages/visualizations-react/src/index.ts
+++ b/packages/visualizations-react/src/index.ts
@@ -1,3 +1,5 @@
+import '@opendatasoft/visualizations/dist/index.css';
+
 import {
     Chart as _Chart,
     KpiCard as _KpiCard,

--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Column, TableOptions, TableData, Async } from '@opendatasoft/visualizations';
 
+import './custom-style.css';
+
 import { Table } from '../../src';
 
 import value from './data';

--- a/packages/visualizations-react/stories/Table/custom-style.css
+++ b/packages/visualizations-react/stories/Table/custom-style.css
@@ -1,0 +1,16 @@
+.table-story--custom-style .table-wrapper {
+    border-color: #fcd4cf;
+}
+.table-story--custom-style thead {
+    border-bottom-color: #f94346;
+    border-bottom-width: 2px;
+    background-color: #fd635d;
+    color:#ffffff;
+}
+
+.table-story--custom-style tbody tr {
+    border-bottom-color: #fcd4cf;
+}
+.table-story--custom-style tbody tr:hover {
+    background-color: #f9aea4;
+}

--- a/packages/visualizations-react/test/__mocks__/styleMock.js
+++ b/packages/visualizations-react/test/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
## Summary

The goal for this PR fix style missing in visualizations-react

(Internal for Opendatasoft only) Associated Shortcut ticket: 🏴‍☠️ 

### Changes

React bundle import visualizations style. 
Storybook no longer need to import the visualizations style sheet

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
