### PR TITLE
feat: add preserveDrawingBuffer option to POI maps

### DIFF
--- a/packages/visualizations/src/components/MapPoi/Map.svelte
+++ b/packages/visualizations/src/components/MapPoi/Map.svelte
@@ -40,6 +40,7 @@
         images,
         transformRequest,
         cooperativeGestures,
+        preserveDrawingBuffer,
     } = getMapOptions(options));
 
     const bbox = createDeepEqual(_bbox);
@@ -70,6 +71,7 @@
             {images}
             {transformRequest}
             {cooperativeGestures}
+            {preserveDrawingBuffer}
         />
     {/key}
 </div>

--- a/packages/visualizations/src/components/MapPoi/MapRender.svelte
+++ b/packages/visualizations/src/components/MapPoi/MapRender.svelte
@@ -39,6 +39,7 @@
     export let legend: CategoryLegendType | undefined;
     export let description: string | undefined;
     export let cooperativeGestures: boolean | GestureOptions | undefined;
+    export let preserveDrawingBuffer: boolean;
     // Data source link
     export let sourceLink: Source | undefined;
 
@@ -73,6 +74,7 @@
             minZoom,
             maxZoom,
             cooperativeGestures,
+            preserveDrawingBuffer,
         };
         map.initialize(style, container, options);
     });

--- a/packages/visualizations/src/components/MapPoi/types.ts
+++ b/packages/visualizations/src/components/MapPoi/types.ts
@@ -58,6 +58,8 @@ export interface PoiMapOptions {
     /** Link button to source */
     sourceLink?: Source;
     cooperativeGestures?: boolean | GestureOptions;
+    /** If true, the map's canvas can be exported to a PNG using toDataURL. This is false by default as a performance optimization. */
+    preserveDrawingBuffer?: boolean;
     /** Images to load by the Map. keys are image ids  */
     images?: Images;
 }

--- a/packages/visualizations/src/components/MapPoi/utils.ts
+++ b/packages/visualizations/src/components/MapPoi/utils.ts
@@ -172,6 +172,7 @@ export const getMapOptions = (options: PoiMapOptions) => {
         sourceLink,
         transformRequest,
         cooperativeGestures,
+        preserveDrawingBuffer = false,
         images,
     } = options;
     return {
@@ -189,6 +190,7 @@ export const getMapOptions = (options: PoiMapOptions) => {
         sourceLink,
         transformRequest,
         cooperativeGestures,
+        preserveDrawingBuffer,
         images,
     };
 };


### PR DESCRIPTION
## Summary

The goal for this PR is to expose the mapLibre preserveDrawingBuffer option to enable toDataUrl for POI maps PNG exports.

For now it's just a draft for experimentation.

## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
