### PR TITLE
[sc-46254] Add CSS style for vertical scroll

### DIFF
--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -28,6 +28,12 @@ Playground.args = {
     options,
 };
 
+export const VerticalScroll = Template.bind({});
+VerticalScroll.args = {
+    data,
+    options: { ...options, verticalScroll: true },
+}
+
 const CustomStyleTemplate: ComponentStory<typeof Table> = args => (
     <div className="table-story--custom-style">
         <Table {...args} />

--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -28,11 +28,17 @@ Playground.args = {
     options,
 };
 
-export const VerticalScroll = Template.bind({});
+const BoxSizingTemplate: ComponentStory<typeof Table> = args => (
+    <div className='table-story--box-sizing'>
+        <Table {...args} />
+    </div>
+);
+
+export const VerticalScroll = BoxSizingTemplate.bind({});
 VerticalScroll.args = {
     data,
     options: { ...options, verticalScroll: true },
-}
+};
 
 const CustomStyleTemplate: ComponentStory<typeof Table> = args => (
     <div className="table-story--custom-style">

--- a/packages/visualizations-react/stories/Table/custom-style.css
+++ b/packages/visualizations-react/stories/Table/custom-style.css
@@ -1,6 +1,7 @@
 .table-story--custom-style .table-wrapper {
     border-color: #fcd4cf;
 }
+
 .table-story--custom-style thead {
     border-bottom-color: #f94346;
     border-bottom-width: 2px;
@@ -11,6 +12,7 @@
 .table-story--custom-style tbody tr {
     border-bottom-color: #fcd4cf;
 }
+
 .table-story--custom-style tbody tr:hover {
     background-color: #f9aea4;
 }
@@ -35,4 +37,8 @@
 .design-system svg {
     --selected: #142e7b;
     --neutral: #cbd2db;
+}
+
+.table-story--box-sizing {
+    height: 20em;
 }

--- a/packages/visualizations/src/components/Table/Headers/Headers.svelte
+++ b/packages/visualizations/src/components/Table/Headers/Headers.svelte
@@ -3,9 +3,10 @@
     import type { Column } from '../types';
 
     export let columns: Column[];
+    export let verticalScroll: boolean | undefined;
 </script>
 
-<thead>
+<thead class:sticky-top={verticalScroll}>
     <tr>
         {#each columns as column}
             <th class={`table-header--${column.dataFormat}`}>
@@ -36,5 +37,12 @@
 
     :global(.ods-dataviz--default th.table-header--number) {
         text-align: right;
+    }
+    
+    thead.sticky-top {
+        background-color: var(--header-background-color);
+        box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.26);
+        position: sticky;
+        top: 0;
     }
 </style>

--- a/packages/visualizations/src/components/Table/Headers/Headers.svelte
+++ b/packages/visualizations/src/components/Table/Headers/Headers.svelte
@@ -38,7 +38,7 @@
     :global(.ods-dataviz--default th.table-header--number) {
         text-align: right;
     }
-    
+
     thead.sticky-top {
         background-color: var(--header-background-color);
         box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.26);

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -15,7 +15,7 @@
 
 <div class:vscroll-wrapper={verticalScroll}>
     <table aria-describedby={description ? tableId : undefined}>
-        <Headers {columns} {verticalScroll}/>
+        <Headers {columns} {verticalScroll} />
         {#if records}
             <Body {records} {columns} />
         {/if}

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -48,7 +48,6 @@
 
     .vscroll-wrapper {
         display: inline-block;
-        height: var(--vertical-scroll-height);
         overflow-y: scroll;
     }
 </style>

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -8,13 +8,14 @@
     export let columns: Column[];
     export let records: DataFrame | undefined;
     export let description: string | undefined;
+    export let verticalScroll: boolean | undefined;
 
     const tableId = `table-${generateId()}`;
 </script>
 
-<div>
+<div class:vscroll-wrapper={verticalScroll}>
     <table aria-describedby={description ? tableId : undefined}>
-        <Headers {columns} />
+        <Headers {columns} {verticalScroll}/>
         {#if records}
             <Body {records} {columns} />
         {/if}
@@ -43,5 +44,11 @@
         border-collapse: collapse;
         white-space: nowrap;
         width: inherit;
+    }
+
+    .vscroll-wrapper {
+        display: inline-block;
+        height: var(--vertical-scroll-height);
+        overflow-y: scroll;
     }
 </style>

--- a/packages/visualizations/src/components/Table/TableCard.svelte
+++ b/packages/visualizations/src/components/Table/TableCard.svelte
@@ -21,6 +21,7 @@
         unstyled,
         locale: localeOption,
         pagination,
+        verticalScroll,
     } = options);
     $: $locale = localeOption || navigator.language;
     /* Preserves paginations controls positioning
@@ -30,7 +31,7 @@
 
 <Card {title} {subtitle} {source} defaultStyle={!unstyled}>
     <div>
-        <Table {records} {columns} {description} />
+        <Table {records} {columns} {description} {verticalScroll}/>
         {#if pagination}
             <Pagination {...pagination} />
         {/if}

--- a/packages/visualizations/src/components/Table/TableCard.svelte
+++ b/packages/visualizations/src/components/Table/TableCard.svelte
@@ -44,5 +44,6 @@
         display: flex;
         flex-direction: column;
         justify-content: space-between;
+        height: inherit;
     }
 </style>

--- a/packages/visualizations/src/components/Table/TableCard.svelte
+++ b/packages/visualizations/src/components/Table/TableCard.svelte
@@ -31,7 +31,7 @@
 
 <Card {title} {subtitle} {source} defaultStyle={!unstyled}>
     <div>
-        <Table {records} {columns} {description} {verticalScroll}/>
+        <Table {records} {columns} {description} {verticalScroll} />
         {#if pagination}
             <Pagination {...pagination} />
         {/if}

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -107,6 +107,7 @@ export type TableOptions = {
      */
     unstyled?: boolean;
     pagination?: Pagination;
+    verticalScroll?: boolean;
 };
 
 export type TableProps = {

--- a/packages/visualizations/src/components/utils/Card.svelte
+++ b/packages/visualizations/src/components/utils/Card.svelte
@@ -49,8 +49,9 @@
         --vertical-scroll-height: 20em;
         /* FIXME: Only using flex style to center source link */
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         flex-direction: column;
         width: 100%;
+        height: 100%;
     }
 </style>

--- a/packages/visualizations/src/components/utils/Card.svelte
+++ b/packages/visualizations/src/components/utils/Card.svelte
@@ -45,6 +45,8 @@
         --spacing-75: 9px;
         --spacing-100: 13px;
         --border-color: #cbd2db;
+        --header-background-color: #ffffff;
+        --vertical-scroll-height: 20em;
         /* FIXME: Only using flex style to center source link */
         display: flex;
         flex-wrap: wrap;


### PR DESCRIPTION


## Summary

The goal for this PR is to add a fixed header when the `Table` is scrollable vertically.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-46254](https://app.shortcut.com/opendatasoft/story/46254/sdk-table-fixed-headers-and-footers).


https://github.com/opendatasoft/ods-dataviz-sdk/assets/78358994/e07eb056-d3fc-4fde-a65f-5fd0dd8e8050


### Changes

- add `verticalScroll` property
- add new CSS entry `header-background-color`
- add new CSS entry `vertical-scroll-height`
- `thead` is sticky on top
- new story for `Vertical Scroll`

#### Breaking Changes
None

### Changelog

In the `Table` component, the header is now sticky on top when the table is scrollable vertically.

## Open discussion

When the `verticalScroll` property is set to `true`, table height is set arbitrarily and the background color too (default: #ffffff). It's not ideal but I don't see an alternative.

## To be tested

A new story has been created for storybook.

## Review checklist

- [X] Description is complete
- [X] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [X] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
