### PR TITLE
Loading records implementation

### DIFF
--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -20,6 +20,11 @@ const data: Async<TableData> = {
     loading: false,
 };
 
+const fetchingData: Async<TableData> = {
+    value: [],
+    loading: true,
+};
+
 const Template: ComponentStory<typeof Table> = args => <Table {...args} />;
 
 export const Playground = Template.bind({});
@@ -76,4 +81,12 @@ export const Unstyled = Template.bind({});
 Unstyled.args = {
     data,
     options: { ...options, unstyled: true },
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+    data: fetchingData,
+    options: {
+        ...options,
+    },
 };

--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -86,7 +86,5 @@ Unstyled.args = {
 export const Loading = Template.bind({});
 Loading.args = {
     data: fetchingData,
-    options: {
-        ...options,
-    },
+    options,
 };

--- a/packages/visualizations/src/components/Table/Body.svelte
+++ b/packages/visualizations/src/components/Table/Body.svelte
@@ -2,18 +2,30 @@
     import type { Column, TableData } from './types';
     import Cell from './Cell';
 
+    export let isLoading: boolean | undefined;
+    export let loadingRowsNumber: number | undefined;
     export let columns: Column[];
     export let records: TableData;
 </script>
 
 <tbody>
-    {#each records as record}
-        <tr>
-            {#each columns as column}
-                <Cell rawValue={record[column.key]} {column} />
-            {/each}
-        </tr>
-    {/each}
+    {#if isLoading}
+        {#each Array(loadingRowsNumber) as _, index (index)}
+            <tr>
+                {#each columns as column}
+                    <Cell {isLoading} {column} />
+                {/each}
+            </tr>
+        {/each}
+    {:else}
+        {#each records as record}
+            <tr>
+                {#each columns as column}
+                    <Cell rawValue={record[column.key]} {column} />
+                {/each}
+            </tr>
+        {/each}
+    {/if}
 </tbody>
 
 <style>

--- a/packages/visualizations/src/components/Table/Body.svelte
+++ b/packages/visualizations/src/components/Table/Body.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
     import type { Column, TableData } from './types';
-    import Cell from './Cell';
+    import Cell, { LoadingCell } from './Cell';
 
-    export let isLoading: boolean | undefined;
-    export let loadingRowsNumber: number | undefined;
+    export let loadingRowsNumber: number | null;
     export let columns: Column[];
     export let records: TableData;
 </script>
 
 <tbody>
-    {#if isLoading}
-        {#each Array(loadingRowsNumber) as _, index (index)}
+    {#if loadingRowsNumber}
+        {#each Array(loadingRowsNumber) as _}
             <tr>
-                {#each columns as column}
-                    <Cell {isLoading} {column} />
+                {#each columns as __}
+                    <LoadingCell />
                 {/each}
             </tr>
         {/each}

--- a/packages/visualizations/src/components/Table/Cell/Cell.svelte
+++ b/packages/visualizations/src/components/Table/Cell/Cell.svelte
@@ -2,7 +2,8 @@
     import type { Column } from '../types';
     import Format, { isValidRawValue } from './Format';
 
-    export let rawValue: unknown;
+    export let isLoading: boolean | undefined;
+    export let rawValue: unknown | undefined;
     export let column: Column;
 
     $: ({ dataFormat, options = {} } = column);
@@ -10,7 +11,9 @@
 
 <!-- To display a format value, rawValue must be different from undefined or null -->
 <td class={`table-data--${dataFormat}`}>
-    {#if isValidRawValue(rawValue)}
+    {#if isLoading}
+        <div />
+    {:else if isValidRawValue(rawValue)}
         <svelte:component this={Format[dataFormat]} {rawValue} {...options} />
     {/if}
 </td>
@@ -43,5 +46,34 @@
     }
     :global(.ods-dataviz--default td.table-data--number) {
         text-align: right;
+    }
+
+    div {
+        min-height: 21px;
+        width: 100%;
+        background-color: #f6f8fb;
+        border-radius: 3px;
+        overflow: hidden;
+        position: relative;
+    }
+    div::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 60%;
+        height: 100%;
+        background-color: #cbd2db;
+        filter: blur(26px);
+        animation: move 800ms linear 0s infinite alternate both;
+    }
+
+    @keyframes move {
+        0% {
+            transform: translateX(-100%);
+        }
+        100% {
+            transform: translateX(200%);
+        }
     }
 </style>

--- a/packages/visualizations/src/components/Table/Cell/Cell.svelte
+++ b/packages/visualizations/src/components/Table/Cell/Cell.svelte
@@ -2,8 +2,7 @@
     import type { Column } from '../types';
     import Format, { isValidRawValue } from './Format';
 
-    export let isLoading: boolean | undefined;
-    export let rawValue: unknown | undefined;
+    export let rawValue: unknown;
     export let column: Column;
 
     $: ({ dataFormat, options = {} } = column);
@@ -11,9 +10,7 @@
 
 <!-- To display a format value, rawValue must be different from undefined or null -->
 <td class={`table-data--${dataFormat}`}>
-    {#if isLoading}
-        <div />
-    {:else if isValidRawValue(rawValue)}
+    {#if isValidRawValue(rawValue)}
         <svelte:component this={Format[dataFormat]} {rawValue} {...options} />
     {/if}
 </td>
@@ -46,34 +43,5 @@
     }
     :global(.ods-dataviz--default td.table-data--number) {
         text-align: right;
-    }
-
-    div {
-        min-height: 21px;
-        width: 100%;
-        background-color: #f6f8fb;
-        border-radius: 3px;
-        overflow: hidden;
-        position: relative;
-    }
-    div::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 60%;
-        height: 100%;
-        background-color: #cbd2db;
-        filter: blur(26px);
-        animation: move 800ms linear 0s infinite alternate both;
-    }
-
-    @keyframes move {
-        0% {
-            transform: translateX(-100%);
-        }
-        100% {
-            transform: translateX(200%);
-        }
     }
 </style>

--- a/packages/visualizations/src/components/Table/Cell/LoadingCell.svelte
+++ b/packages/visualizations/src/components/Table/Cell/LoadingCell.svelte
@@ -1,0 +1,34 @@
+<td>
+    <div />
+</td>
+
+<style>
+    div {
+        min-height: 21px;
+        width: 100%;
+        background-color: #f6f8fb;
+        border-radius: 3px;
+        overflow: hidden;
+        position: relative;
+    }
+    div::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 60%;
+        height: 100%;
+        background-color: #cbd2db;
+        filter: blur(26px);
+        animation: move 800ms linear 0s infinite alternate both;
+    }
+
+    @keyframes move {
+        0% {
+            transform: translateX(-100%);
+        }
+        100% {
+            transform: translateX(200%);
+        }
+    }
+</style>

--- a/packages/visualizations/src/components/Table/Cell/index.ts
+++ b/packages/visualizations/src/components/Table/Cell/index.ts
@@ -1,3 +1,5 @@
 import Cell from './Cell.svelte';
+import LoadingCell from './LoadingCell.svelte';
 
+export { LoadingCell };
 export default Cell;

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -5,6 +5,8 @@
     import Headers from './Headers';
     import Body from './Body.svelte';
 
+    export let isLoading: boolean | undefined;
+    export let loadingRowsNumber: number;
     export let columns: Column[];
     export let records: DataFrame | undefined;
     export let description: string | undefined;
@@ -16,7 +18,7 @@
     <table aria-describedby={description ? tableId : undefined}>
         <Headers {columns} />
         {#if records}
-            <Body {records} {columns} />
+            <Body {isLoading} {loadingRowsNumber} {records} {columns} />
         {/if}
     </table>
 </div>

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -5,8 +5,7 @@
     import Headers from './Headers';
     import Body from './Body.svelte';
 
-    export let isLoading: boolean | undefined;
-    export let loadingRowsNumber: number;
+    export let loadingRowsNumber: number | null;
     export let columns: Column[];
     export let records: DataFrame | undefined;
     export let description: string | undefined;
@@ -18,7 +17,7 @@
     <table aria-describedby={description ? tableId : undefined}>
         <Headers {columns} />
         {#if records}
-            <Body {isLoading} {loadingRowsNumber} {records} {columns} />
+            <Body {loadingRowsNumber} {records} {columns} />
         {/if}
     </table>
 </div>

--- a/packages/visualizations/src/components/Table/TableCard.svelte
+++ b/packages/visualizations/src/components/Table/TableCard.svelte
@@ -11,7 +11,7 @@
     export let data: $$Props['data'];
     export let options: $$Props['options'];
 
-    $: ({ value: records } = data);
+    $: ({ value: records, loading: isLoading } = data);
     $: ({
         columns,
         title,
@@ -23,6 +23,7 @@
         pagination,
     } = options);
     $: $locale = localeOption || navigator.language;
+    $: loadingRowsNumber = pagination ? pagination.recordsPerPage : 5;
     /* Preserves paginations controls positioning
     min heigh of table + controls = max-height of row * (number of rows) + headers + pagination
     */
@@ -30,7 +31,7 @@
 
 <Card {title} {subtitle} {source} defaultStyle={!unstyled}>
     <div>
-        <Table {records} {columns} {description} />
+        <Table {isLoading} {loadingRowsNumber} {records} {columns} {description} />
         {#if pagination}
             <Pagination {...pagination} />
         {/if}

--- a/packages/visualizations/src/components/Table/TableCard.svelte
+++ b/packages/visualizations/src/components/Table/TableCard.svelte
@@ -23,7 +23,8 @@
         pagination,
     } = options);
     $: $locale = localeOption || navigator.language;
-    $: loadingRowsNumber = pagination ? pagination.recordsPerPage : 5;
+    $: defaultLoadingRowsNumber = pagination ? pagination.recordsPerPage : 5;
+    $: loadingRowsNumber = isLoading ? defaultLoadingRowsNumber : null;
     /* Preserves paginations controls positioning
     min heigh of table + controls = max-height of row * (number of rows) + headers + pagination
     */
@@ -31,7 +32,7 @@
 
 <Card {title} {subtitle} {source} defaultStyle={!unstyled}>
     <div>
-        <Table {isLoading} {loadingRowsNumber} {records} {columns} {description} />
+        <Table {loadingRowsNumber} {records} {columns} {description} />
         {#if pagination}
             <Pagination {...pagination} />
         {/if}


### PR DESCRIPTION
## Summary

The goal for this PR is to add a loading indicator in the rows, when `Table` awaiting new data. 

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-48032](https://app.shortcut.com/opendatasoft/story/48032/sdk-studio-implement-loading-records).

### Changes

Add new subcomponent `LoadingCell` who is displayed when the property `isLoading` is true.

#### Breaking Changes

None

### Changelog

In the Table component a new svg is displayed when fetching the data.

## Open discussion

There are 2 issues that I cannot resolve:
- the SVG is too high in the cell and I don't understand why
- the SVG is not displayed correctly in the different table cells (it only seems to fit the first cell)

## To be tested

New story in storybook

## Review checklist

- [X] Description is complete
- [X] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [X] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
