### PR TITLE
fix: align sort number right and color sort field

### DIFF
--- a/packages/visualizations-react/stories/Table/custom-style.css
+++ b/packages/visualizations-react/stories/Table/custom-style.css
@@ -32,6 +32,10 @@
     color: #808080;
 }
 
+.design-system {
+    color: blue;
+}
+
 .design-system svg {
     --selected: #142e7b;
     --neutral: #cbd2db;

--- a/packages/visualizations/src/components/Table/Headers/SortButton.svelte
+++ b/packages/visualizations/src/components/Table/Headers/SortButton.svelte
@@ -19,6 +19,7 @@
         font-size: inherit;
         font-weight: inherit;
         text-align: inherit;
+        color: inherit;
         border: none;
         background: transparent;
         box-shadow: none;
@@ -28,5 +29,9 @@
         padding: 0;
         display: flex;
         justify-content: space-between;
+    }
+
+    :global(.ods-dataviz--default th.table-header--number button) {
+        justify-content: flex-end;
     }
 </style>


### PR DESCRIPTION
## Summary

The goal for this PR is to align number header right, wether they are sortable or not (design request) and to inherit color for the button—else the sortable field would not inherit theme color.
