### PR TITLE
Export svelte uncompiled components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28540,7 +28540,7 @@
     },
     "packages/visualizations": {
       "name": "@opendatasoft/visualizations",
-      "version": "0.24.1",
+      "version": "0.24.1-beta.0",
       "license": "MIT",
       "dependencies": {
         "@placemarkio/geo-viewport": "^1.0.2",
@@ -28613,10 +28613,10 @@
     },
     "packages/visualizations-react": {
       "name": "@opendatasoft/visualizations-react",
-      "version": "0.24.1",
+      "version": "0.24.1-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@opendatasoft/visualizations": "0.24.1",
+        "@opendatasoft/visualizations": "0.24.1-beta.0",
         "use-callback-ref": "^1.2.4"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3048,9 +3048,8 @@
     },
     "node_modules/@lerna/create/node_modules/@nrwl/tao": {
       "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-18.3.5.tgz",
-      "integrity": "sha512-gB7Vxa6FReZZEGva03Eh+84W8BSZOjsNyXboglOINu6d8iZZ0eotSXGziKgjpkj3feZ1ofKZMs0PRObVAOROVw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "nx": "18.3.5",
         "tslib": "^2.3.0"
@@ -3077,161 +3076,16 @@
         "nx": ">= 16 <= 18"
       }
     },
-    "node_modules/@lerna/create/node_modules/@nx/nx-darwin-arm64": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.3.5.tgz",
-      "integrity": "sha512-4I5UpZ/x2WO9OQyETXKjaYhXiZKUTYcLPewruRMODWu6lgTM9hHci0SqMQB+TWe3f80K8VT8J8x3+uJjvllGlg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@lerna/create/node_modules/@nx/nx-darwin-x64": {
       "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-18.3.5.tgz",
-      "integrity": "sha512-Drn6jOG237AD/s6OWPt06bsMj0coGKA5Ce1y5gfLhptOGk4S4UPE/Ay5YCjq+/yhTo1gDHzCHxH0uW2X9MN9Fg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@lerna/create/node_modules/@nx/nx-freebsd-x64": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.3.5.tgz",
-      "integrity": "sha512-8tA8Yw0Iir4liFjffIFS5THTS3TtWY/No2tkVj91gwy/QQ/otvKbOyc5RCIPpbZU6GS3ZWfG92VyCSm06dtMFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@lerna/create/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.3.5.tgz",
-      "integrity": "sha512-BrPGAHM9FCGkB9/hbvlJhe+qtjmvpjIjYixGIlUxL3gGc8E/ucTyCnz5pRFFPFQlBM7Z/9XmbHvGPoUi/LYn5A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@lerna/create/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.3.5.tgz",
-      "integrity": "sha512-/Xd0Q3LBgJeigJqXC/Jck/9l5b+fK+FCM0nRFMXgPXrhZPhoxWouFkoYl2F1Ofr+AQf4jup4DkVTB5r98uxSCA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@lerna/create/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.3.5.tgz",
-      "integrity": "sha512-r18qd7pUrl1haAZ/e9Q+xaFTsLJnxGARQcf/Y76q+K2psKmiUXoRlqd3HAOw43KTllaUJ5HkzLq2pIwg3p+xBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@lerna/create/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.3.5.tgz",
-      "integrity": "sha512-vYrikG6ff4I9cvr3Ysk3y3gjQ9cDcvr3iAr+4qqcQ4qVE+OLL2++JDS6xfPvG/TbS3GTQpyy2STRBwiHgxTeJw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@lerna/create/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.3.5.tgz",
-      "integrity": "sha512-6np86lcYy3+x6kkW/HrBHIdNWbUu/MIsvMuNH5UXgyFs60l5Z7Cocay2f7WOaAbTLVAr0W7p4RxRPamHLRwWFA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@lerna/create/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.3.5.tgz",
-      "integrity": "sha512-H3p2ZVhHV1WQWTICrQUTplOkNId0y3c23X3A2fXXFDbWSBs0UgW7m55LhMcA9p0XZ7wDHgh+yFtVgu55TXLjug==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@lerna/create/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.3.5.tgz",
-      "integrity": "sha512-xFwKVTIXSgjdfxkpriqHv5NpmmFILTrWLEkUGSoimuRaAm1u15YWx/VmaUQ+UWuJnmgqvB/so4SMHSfNkq3ijA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -3239,9 +3093,8 @@
     },
     "node_modules/@lerna/create/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -3292,9 +3145,8 @@
     },
     "node_modules/@lerna/create/node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3304,9 +3156,8 @@
     },
     "node_modules/@lerna/create/node_modules/lines-and-columns": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -3332,10 +3183,9 @@
     },
     "node_modules/@lerna/create/node_modules/nx": {
       "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-18.3.5.tgz",
-      "integrity": "sha512-wWcvwoTgiT5okdrG0RIWm1tepC17bDmSpw+MrOxnjfBjARQNTURkiq4U6cxjCVsCxNHxCrlAaBSQLZeBgJZTzQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@nrwl/tao": "18.3.5",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -3403,18 +3253,16 @@
     },
     "node_modules/@lerna/create/node_modules/nx/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@lerna/create/node_modules/nx/node_modules/minimatch": {
       "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3427,9 +3275,8 @@
     },
     "node_modules/@lerna/create/node_modules/ora": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
-      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
         "chalk": "^4.1.0",
@@ -3466,9 +3313,8 @@
     },
     "node_modules/@lerna/create/node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -3483,9 +3329,8 @@
     },
     "node_modules/@lerna/create/node_modules/tsconfig-paths": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",
@@ -3745,9 +3590,8 @@
     },
     "node_modules/@nrwl/devkit/node_modules/@nrwl/tao": {
       "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-18.3.5.tgz",
-      "integrity": "sha512-gB7Vxa6FReZZEGva03Eh+84W8BSZOjsNyXboglOINu6d8iZZ0eotSXGziKgjpkj3feZ1ofKZMs0PRObVAOROVw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "nx": "18.3.5",
@@ -3775,170 +3619,16 @@
         "nx": ">= 16 <= 18"
       }
     },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-darwin-arm64": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.3.5.tgz",
-      "integrity": "sha512-4I5UpZ/x2WO9OQyETXKjaYhXiZKUTYcLPewruRMODWu6lgTM9hHci0SqMQB+TWe3f80K8VT8J8x3+uJjvllGlg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-darwin-x64": {
       "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-18.3.5.tgz",
-      "integrity": "sha512-Drn6jOG237AD/s6OWPt06bsMj0coGKA5Ce1y5gfLhptOGk4S4UPE/Ay5YCjq+/yhTo1gDHzCHxH0uW2X9MN9Fg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-freebsd-x64": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.3.5.tgz",
-      "integrity": "sha512-8tA8Yw0Iir4liFjffIFS5THTS3TtWY/No2tkVj91gwy/QQ/otvKbOyc5RCIPpbZU6GS3ZWfG92VyCSm06dtMFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.3.5.tgz",
-      "integrity": "sha512-BrPGAHM9FCGkB9/hbvlJhe+qtjmvpjIjYixGIlUxL3gGc8E/ucTyCnz5pRFFPFQlBM7Z/9XmbHvGPoUi/LYn5A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.3.5.tgz",
-      "integrity": "sha512-/Xd0Q3LBgJeigJqXC/Jck/9l5b+fK+FCM0nRFMXgPXrhZPhoxWouFkoYl2F1Ofr+AQf4jup4DkVTB5r98uxSCA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.3.5.tgz",
-      "integrity": "sha512-r18qd7pUrl1haAZ/e9Q+xaFTsLJnxGARQcf/Y76q+K2psKmiUXoRlqd3HAOw43KTllaUJ5HkzLq2pIwg3p+xBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.3.5.tgz",
-      "integrity": "sha512-vYrikG6ff4I9cvr3Ysk3y3gjQ9cDcvr3iAr+4qqcQ4qVE+OLL2++JDS6xfPvG/TbS3GTQpyy2STRBwiHgxTeJw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.3.5.tgz",
-      "integrity": "sha512-6np86lcYy3+x6kkW/HrBHIdNWbUu/MIsvMuNH5UXgyFs60l5Z7Cocay2f7WOaAbTLVAr0W7p4RxRPamHLRwWFA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.3.5.tgz",
-      "integrity": "sha512-H3p2ZVhHV1WQWTICrQUTplOkNId0y3c23X3A2fXXFDbWSBs0UgW7m55LhMcA9p0XZ7wDHgh+yFtVgu55TXLjug==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.3.5.tgz",
-      "integrity": "sha512-xFwKVTIXSgjdfxkpriqHv5NpmmFILTrWLEkUGSoimuRaAm1u15YWx/VmaUQ+UWuJnmgqvB/so4SMHSfNkq3ijA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "peer": true,
       "engines": {
@@ -3947,9 +3637,8 @@
     },
     "node_modules/@nrwl/devkit/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3957,9 +3646,8 @@
     },
     "node_modules/@nrwl/devkit/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
@@ -3972,9 +3660,8 @@
     },
     "node_modules/@nrwl/devkit/node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -3985,9 +3672,8 @@
     },
     "node_modules/@nrwl/devkit/node_modules/lines-and-columns": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -3995,9 +3681,8 @@
     },
     "node_modules/@nrwl/devkit/node_modules/minimatch": {
       "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -4011,10 +3696,9 @@
     },
     "node_modules/@nrwl/devkit/node_modules/nx": {
       "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-18.3.5.tgz",
-      "integrity": "sha512-wWcvwoTgiT5okdrG0RIWm1tepC17bDmSpw+MrOxnjfBjARQNTURkiq4U6cxjCVsCxNHxCrlAaBSQLZeBgJZTzQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@nrwl/tao": "18.3.5",
@@ -4083,9 +3767,8 @@
     },
     "node_modules/@nrwl/devkit/node_modules/ora": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
-      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
@@ -4106,9 +3789,8 @@
     },
     "node_modules/@nrwl/devkit/node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -4124,9 +3806,8 @@
     },
     "node_modules/@nrwl/devkit/node_modules/tsconfig-paths": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "json5": "^2.2.2",
@@ -4139,9 +3820,8 @@
     },
     "node_modules/@nrwl/tao": {
       "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-19.0.7.tgz",
-      "integrity": "sha512-tWUUsFZiu6KxMO3Q1mYm7HQh0XXQOIsJaxuuNO2UFBdfsE/P5GKUe6SuKyBmfoOY+LcZcBL/nlaJ02hJkCe7Sg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "nx": "19.0.7",
         "tslib": "^2.3.0"
@@ -4150,161 +3830,16 @@
         "tao": "index.js"
       }
     },
-    "node_modules/@nx/nx-darwin-arm64": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.0.7.tgz",
-      "integrity": "sha512-tMcYKJzldLAAF3RuHE8+SA+M4nJzQBiv4CuDChdkQ6nqoDndg3uqJ2U7rwmrNu+VJXLxJzbnWdFzaupkfu9FpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@nx/nx-darwin-x64": {
       "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.0.7.tgz",
-      "integrity": "sha512-c3WFxHEEY/1GuSGVHREIbK19gEXnl09Rx93Sx10gPCqk2OWu6nogCg3UfY3yYzpm3c7qWOXzj/dvSRCTmzcEGQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-freebsd-x64": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.0.7.tgz",
-      "integrity": "sha512-WrteQTg/4zYqHciEmwnPje87XooqUeu8kemHDLt83BQ538AxqAp9R2DoW+JSbwHOq4ZYK7nVzQRwNbuZ7/7bkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.0.7.tgz",
-      "integrity": "sha512-jrJQYf63LCOClYDfl2Rgg/rQvA/qOoCvmEIB8XI/9TCfeRU7Zoa+dxVC6nKG02DzFaarY3zdQ2GFzYd0wpTFvg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.0.7.tgz",
-      "integrity": "sha512-0ekdp8+8NzFsiK3EQu9eg8W/z5ehjlPF38Vy+Pb7T3xM7pR8Kpx0k5B2D2/StPBQU8ENdyDxspBch9FnZsSbYg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.0.7.tgz",
-      "integrity": "sha512-d0a3iIobeYJY4b8HdwsohGt1d7TMKQJM0nWI3xcbqotLSovFoL6CqNn3g7uZhZPhNwQXNtSEwaXfQRZcH9Nr1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.0.7.tgz",
-      "integrity": "sha512-C75zX747Fwc/oH8Xk6+U4xBG97BYka5hGU57034cQVMHKaDfivVHKfwBuROVkj3Mg96QbAS3rAAfMtaCthMLTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.0.7.tgz",
-      "integrity": "sha512-OzPtwGp4ENsRI5J35kbjXE0hDbTNF1QwnK3O7R7H1Ew9WJjZi3tEm1cTsq0/SssI6YbZqRhzrNBd/N7Mkjd2dA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.0.7.tgz",
-      "integrity": "sha512-G17tdQEjE6eAWRO4XFGpoFHZ55M1AVmj+CJwaTowzXDSk26y3waoDUGOy75ft1LLoz5i8Q9CWFG4Fnyno4Bv/g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.0.7.tgz",
-      "integrity": "sha512-ZK4w5w9khgphyqEf/cKSyZsmHD4np7/sNp25D9Fdr5z6RTu2U73K07/e3nj2jS2ZCIrjPxobAGljZdXom9LH7g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -8418,9 +7953,8 @@
     },
     "node_modules/@zkochan/js-yaml": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
-      "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -17858,9 +17392,8 @@
     },
     "node_modules/lerna/node_modules/@nrwl/tao": {
       "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-18.3.5.tgz",
-      "integrity": "sha512-gB7Vxa6FReZZEGva03Eh+84W8BSZOjsNyXboglOINu6d8iZZ0eotSXGziKgjpkj3feZ1ofKZMs0PRObVAOROVw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "nx": "18.3.5",
         "tslib": "^2.3.0"
@@ -17887,161 +17420,16 @@
         "nx": ">= 16 <= 18"
       }
     },
-    "node_modules/lerna/node_modules/@nx/nx-darwin-arm64": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.3.5.tgz",
-      "integrity": "sha512-4I5UpZ/x2WO9OQyETXKjaYhXiZKUTYcLPewruRMODWu6lgTM9hHci0SqMQB+TWe3f80K8VT8J8x3+uJjvllGlg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/lerna/node_modules/@nx/nx-darwin-x64": {
       "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-18.3.5.tgz",
-      "integrity": "sha512-Drn6jOG237AD/s6OWPt06bsMj0coGKA5Ce1y5gfLhptOGk4S4UPE/Ay5YCjq+/yhTo1gDHzCHxH0uW2X9MN9Fg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/lerna/node_modules/@nx/nx-freebsd-x64": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.3.5.tgz",
-      "integrity": "sha512-8tA8Yw0Iir4liFjffIFS5THTS3TtWY/No2tkVj91gwy/QQ/otvKbOyc5RCIPpbZU6GS3ZWfG92VyCSm06dtMFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/lerna/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.3.5.tgz",
-      "integrity": "sha512-BrPGAHM9FCGkB9/hbvlJhe+qtjmvpjIjYixGIlUxL3gGc8E/ucTyCnz5pRFFPFQlBM7Z/9XmbHvGPoUi/LYn5A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/lerna/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.3.5.tgz",
-      "integrity": "sha512-/Xd0Q3LBgJeigJqXC/Jck/9l5b+fK+FCM0nRFMXgPXrhZPhoxWouFkoYl2F1Ofr+AQf4jup4DkVTB5r98uxSCA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/lerna/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.3.5.tgz",
-      "integrity": "sha512-r18qd7pUrl1haAZ/e9Q+xaFTsLJnxGARQcf/Y76q+K2psKmiUXoRlqd3HAOw43KTllaUJ5HkzLq2pIwg3p+xBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/lerna/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.3.5.tgz",
-      "integrity": "sha512-vYrikG6ff4I9cvr3Ysk3y3gjQ9cDcvr3iAr+4qqcQ4qVE+OLL2++JDS6xfPvG/TbS3GTQpyy2STRBwiHgxTeJw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/lerna/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.3.5.tgz",
-      "integrity": "sha512-6np86lcYy3+x6kkW/HrBHIdNWbUu/MIsvMuNH5UXgyFs60l5Z7Cocay2f7WOaAbTLVAr0W7p4RxRPamHLRwWFA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/lerna/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.3.5.tgz",
-      "integrity": "sha512-H3p2ZVhHV1WQWTICrQUTplOkNId0y3c23X3A2fXXFDbWSBs0UgW7m55LhMcA9p0XZ7wDHgh+yFtVgu55TXLjug==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/lerna/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.3.5.tgz",
-      "integrity": "sha512-xFwKVTIXSgjdfxkpriqHv5NpmmFILTrWLEkUGSoimuRaAm1u15YWx/VmaUQ+UWuJnmgqvB/so4SMHSfNkq3ijA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -18049,9 +17437,8 @@
     },
     "node_modules/lerna/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -18102,9 +17489,8 @@
     },
     "node_modules/lerna/node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -18114,9 +17500,8 @@
     },
     "node_modules/lerna/node_modules/lines-and-columns": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -18142,10 +17527,9 @@
     },
     "node_modules/lerna/node_modules/nx": {
       "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-18.3.5.tgz",
-      "integrity": "sha512-wWcvwoTgiT5okdrG0RIWm1tepC17bDmSpw+MrOxnjfBjARQNTURkiq4U6cxjCVsCxNHxCrlAaBSQLZeBgJZTzQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@nrwl/tao": "18.3.5",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -18213,18 +17597,16 @@
     },
     "node_modules/lerna/node_modules/nx/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/lerna/node_modules/nx/node_modules/minimatch": {
       "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -18237,9 +17619,8 @@
     },
     "node_modules/lerna/node_modules/ora": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
-      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
         "chalk": "^4.1.0",
@@ -18276,9 +17657,8 @@
     },
     "node_modules/lerna/node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -18293,9 +17673,8 @@
     },
     "node_modules/lerna/node_modules/tsconfig-paths": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",
@@ -20879,10 +20258,9 @@
     },
     "node_modules/nx": {
       "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-19.0.7.tgz",
-      "integrity": "sha512-9ZgxIvesVwM2941wnq5hvFD28kcABN+Nhf9RvA0P2DeFhOWYNMn1FhdYBrAl7tQB3gZsXrpitM5+f9kqIBzF8g==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@nrwl/tao": "19.0.7",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -20971,9 +20349,8 @@
     "node_modules/nx/node_modules/js-yaml": {
       "name": "@zkochan/js-yaml",
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz",
-      "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "lerna": "^8.1.2",
-        "nx": "^19.0.7"
+        "nx": "^19.2.3"
       }
     },
     "node_modules/-": {
@@ -3076,6 +3076,22 @@
         "nx": ">= 16 <= 18"
       }
     },
+    "node_modules/@lerna/create/node_modules/@nx/nx-darwin-arm64": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.3.5.tgz",
+      "integrity": "sha512-4I5UpZ/x2WO9OQyETXKjaYhXiZKUTYcLPewruRMODWu6lgTM9hHci0SqMQB+TWe3f80K8VT8J8x3+uJjvllGlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@lerna/create/node_modules/@nx/nx-darwin-x64": {
       "version": "18.3.5",
       "cpu": [
@@ -3086,6 +3102,134 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/@nx/nx-freebsd-x64": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.3.5.tgz",
+      "integrity": "sha512-8tA8Yw0Iir4liFjffIFS5THTS3TtWY/No2tkVj91gwy/QQ/otvKbOyc5RCIPpbZU6GS3ZWfG92VyCSm06dtMFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.3.5.tgz",
+      "integrity": "sha512-BrPGAHM9FCGkB9/hbvlJhe+qtjmvpjIjYixGIlUxL3gGc8E/ucTyCnz5pRFFPFQlBM7Z/9XmbHvGPoUi/LYn5A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.3.5.tgz",
+      "integrity": "sha512-/Xd0Q3LBgJeigJqXC/Jck/9l5b+fK+FCM0nRFMXgPXrhZPhoxWouFkoYl2F1Ofr+AQf4jup4DkVTB5r98uxSCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.3.5.tgz",
+      "integrity": "sha512-r18qd7pUrl1haAZ/e9Q+xaFTsLJnxGARQcf/Y76q+K2psKmiUXoRlqd3HAOw43KTllaUJ5HkzLq2pIwg3p+xBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.3.5.tgz",
+      "integrity": "sha512-vYrikG6ff4I9cvr3Ysk3y3gjQ9cDcvr3iAr+4qqcQ4qVE+OLL2++JDS6xfPvG/TbS3GTQpyy2STRBwiHgxTeJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.3.5.tgz",
+      "integrity": "sha512-6np86lcYy3+x6kkW/HrBHIdNWbUu/MIsvMuNH5UXgyFs60l5Z7Cocay2f7WOaAbTLVAr0W7p4RxRPamHLRwWFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.3.5.tgz",
+      "integrity": "sha512-H3p2ZVhHV1WQWTICrQUTplOkNId0y3c23X3A2fXXFDbWSBs0UgW7m55LhMcA9p0XZ7wDHgh+yFtVgu55TXLjug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.3.5.tgz",
+      "integrity": "sha512-xFwKVTIXSgjdfxkpriqHv5NpmmFILTrWLEkUGSoimuRaAm1u15YWx/VmaUQ+UWuJnmgqvB/so4SMHSfNkq3ijA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -3619,6 +3763,23 @@
         "nx": ">= 16 <= 18"
       }
     },
+    "node_modules/@nrwl/devkit/node_modules/@nx/nx-darwin-arm64": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.3.5.tgz",
+      "integrity": "sha512-4I5UpZ/x2WO9OQyETXKjaYhXiZKUTYcLPewruRMODWu6lgTM9hHci0SqMQB+TWe3f80K8VT8J8x3+uJjvllGlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-darwin-x64": {
       "version": "18.3.5",
       "cpu": [
@@ -3629,6 +3790,142 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/devkit/node_modules/@nx/nx-freebsd-x64": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.3.5.tgz",
+      "integrity": "sha512-8tA8Yw0Iir4liFjffIFS5THTS3TtWY/No2tkVj91gwy/QQ/otvKbOyc5RCIPpbZU6GS3ZWfG92VyCSm06dtMFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.3.5.tgz",
+      "integrity": "sha512-BrPGAHM9FCGkB9/hbvlJhe+qtjmvpjIjYixGIlUxL3gGc8E/ucTyCnz5pRFFPFQlBM7Z/9XmbHvGPoUi/LYn5A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.3.5.tgz",
+      "integrity": "sha512-/Xd0Q3LBgJeigJqXC/Jck/9l5b+fK+FCM0nRFMXgPXrhZPhoxWouFkoYl2F1Ofr+AQf4jup4DkVTB5r98uxSCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.3.5.tgz",
+      "integrity": "sha512-r18qd7pUrl1haAZ/e9Q+xaFTsLJnxGARQcf/Y76q+K2psKmiUXoRlqd3HAOw43KTllaUJ5HkzLq2pIwg3p+xBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.3.5.tgz",
+      "integrity": "sha512-vYrikG6ff4I9cvr3Ysk3y3gjQ9cDcvr3iAr+4qqcQ4qVE+OLL2++JDS6xfPvG/TbS3GTQpyy2STRBwiHgxTeJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.3.5.tgz",
+      "integrity": "sha512-6np86lcYy3+x6kkW/HrBHIdNWbUu/MIsvMuNH5UXgyFs60l5Z7Cocay2f7WOaAbTLVAr0W7p4RxRPamHLRwWFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/devkit/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.3.5.tgz",
+      "integrity": "sha512-H3p2ZVhHV1WQWTICrQUTplOkNId0y3c23X3A2fXXFDbWSBs0UgW7m55LhMcA9p0XZ7wDHgh+yFtVgu55TXLjug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/devkit/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.3.5.tgz",
+      "integrity": "sha512-xFwKVTIXSgjdfxkpriqHv5NpmmFILTrWLEkUGSoimuRaAm1u15YWx/VmaUQ+UWuJnmgqvB/so4SMHSfNkq3ijA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "peer": true,
       "engines": {
@@ -3819,27 +4116,173 @@
       }
     },
     "node_modules/@nrwl/tao": {
-      "version": "19.0.7",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-19.2.3.tgz",
+      "integrity": "sha512-vwo6ogcy6A9vJggDOsHGi1F0cTRqSqRypbgq/EdNuZqL7rGyZB/ctId69/i8dV6cLkl8BJG/4WpEe5BIrMTsjA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "nx": "19.0.7",
+        "nx": "19.2.3",
         "tslib": "^2.3.0"
       },
       "bin": {
         "tao": "index.js"
       }
     },
+    "node_modules/@nx/nx-darwin-arm64": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.2.3.tgz",
+      "integrity": "sha512-1beJscdMraGgLHpvjyC5FXUzpdQYW8JwnPK0Yj9iti9Vnahtx3PLQHCFOFwoE0KZF9VEL1KsZSSVPljMgW/j+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "19.0.7",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.2.3.tgz",
+      "integrity": "sha512-wCpIRThGKL/FebPe+WaFk/V6nk31mMc83APoEyhyS5kAodqeKjb6iPud+QNydtUJ/jsF9aQ/DaHIioKC9wbg8A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-freebsd-x64": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.2.3.tgz",
+      "integrity": "sha512-ytY18USCyf83wqyUgFaeRO/3zvysJXPJf1Di8czBhiUSroSMB6088OaeqW7SnzdcYNdACZUv0Q6PupXpx3w2Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.2.3.tgz",
+      "integrity": "sha512-FPtqIMzdOzYSSDnLXUpcrflqEsNe6UgpAgYoHLVbWiR47O3qJnpQRDfYUsP7Lv+2C0CBKNXgwPEvmDLXKHcfYg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.2.3.tgz",
+      "integrity": "sha512-VOuzPD5FBPZmctvXqdB9K1MYVzkV8TgOZFS7Md6ClH7UwJTEOjnMoomYCMM1VlOZV4P0S5E0u/Zere5YWh+ZWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.2.3.tgz",
+      "integrity": "sha512-qd6QZysktt0D7rNCOlBaV3ME0/J0VwvC1cmdjtZoljwtsX6Zc56AEdfwsgGzsZNU4w+N+BtXxowan3D44iiSzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.2.3.tgz",
+      "integrity": "sha512-wE08BstTD65dt6c+9L9bEp98PxFwc7CuaUVX2cZTDFAERBXCMhu7y6Gb1JbiAvfVci4+yLrm+h0E1ieY1wMTXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-x64-musl": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.2.3.tgz",
+      "integrity": "sha512-IA09+NZ0kKPSfK/dXsyjZ8TN+hN/1PcnbdNuUCn1Opmbrdda9GBfzHSDFKXxoA6TVB/j/qnXHKgKxhhVH05TGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.2.3.tgz",
+      "integrity": "sha512-fkbcTp+XuxGaL5e4Ve8AjxNEim5Ifdn61ofaxEDMoGjauKvKZBejbLhBFOonCKDqntXsY8D2nDXjhcsdNYxzMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.2.3.tgz",
+      "integrity": "sha512-E2q3c504xjFXTY+/iq57DOZmS6CPA8RbFwLf6bCG5wo2BDajxmvU3VCeCSkxqXEwCY7NJSI3PT1V/3vRDzJ3lQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -13893,6 +14336,37 @@
       ],
       "license": "MIT"
     },
+    "node_modules/front-matter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.13.1"
+      }
+    },
+    "node_modules/front-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/front-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "dev": true,
@@ -17408,6 +17882,22 @@
         "nx": ">= 16 <= 18"
       }
     },
+    "node_modules/lerna/node_modules/@nx/nx-darwin-arm64": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.3.5.tgz",
+      "integrity": "sha512-4I5UpZ/x2WO9OQyETXKjaYhXiZKUTYcLPewruRMODWu6lgTM9hHci0SqMQB+TWe3f80K8VT8J8x3+uJjvllGlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/lerna/node_modules/@nx/nx-darwin-x64": {
       "version": "18.3.5",
       "cpu": [
@@ -17418,6 +17908,134 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/lerna/node_modules/@nx/nx-freebsd-x64": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.3.5.tgz",
+      "integrity": "sha512-8tA8Yw0Iir4liFjffIFS5THTS3TtWY/No2tkVj91gwy/QQ/otvKbOyc5RCIPpbZU6GS3ZWfG92VyCSm06dtMFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/lerna/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.3.5.tgz",
+      "integrity": "sha512-BrPGAHM9FCGkB9/hbvlJhe+qtjmvpjIjYixGIlUxL3gGc8E/ucTyCnz5pRFFPFQlBM7Z/9XmbHvGPoUi/LYn5A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/lerna/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.3.5.tgz",
+      "integrity": "sha512-/Xd0Q3LBgJeigJqXC/Jck/9l5b+fK+FCM0nRFMXgPXrhZPhoxWouFkoYl2F1Ofr+AQf4jup4DkVTB5r98uxSCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/lerna/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.3.5.tgz",
+      "integrity": "sha512-r18qd7pUrl1haAZ/e9Q+xaFTsLJnxGARQcf/Y76q+K2psKmiUXoRlqd3HAOw43KTllaUJ5HkzLq2pIwg3p+xBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/lerna/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.3.5.tgz",
+      "integrity": "sha512-vYrikG6ff4I9cvr3Ysk3y3gjQ9cDcvr3iAr+4qqcQ4qVE+OLL2++JDS6xfPvG/TbS3GTQpyy2STRBwiHgxTeJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/lerna/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.3.5.tgz",
+      "integrity": "sha512-6np86lcYy3+x6kkW/HrBHIdNWbUu/MIsvMuNH5UXgyFs60l5Z7Cocay2f7WOaAbTLVAr0W7p4RxRPamHLRwWFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/lerna/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.3.5.tgz",
+      "integrity": "sha512-H3p2ZVhHV1WQWTICrQUTplOkNId0y3c23X3A2fXXFDbWSBs0UgW7m55LhMcA9p0XZ7wDHgh+yFtVgu55TXLjug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/lerna/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.3.5.tgz",
+      "integrity": "sha512-xFwKVTIXSgjdfxkpriqHv5NpmmFILTrWLEkUGSoimuRaAm1u15YWx/VmaUQ+UWuJnmgqvB/so4SMHSfNkq3ijA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -20244,14 +20862,16 @@
       "license": "MIT"
     },
     "node_modules/nx": {
-      "version": "19.0.7",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-19.2.3.tgz",
+      "integrity": "sha512-SvxFgk9PD2m6tXEaqB6DENOpe4jhov/Ili/2JmOnPAAIGUR6H9WajCzVuHfq3bvQxmGRvkQQRv/rfvAuLTme3g==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@nrwl/tao": "19.0.7",
+        "@nrwl/tao": "19.2.3",
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "3.0.0-rc.46",
+        "@zkochan/js-yaml": "0.0.7",
         "axios": "^1.6.0",
         "chalk": "^4.1.0",
         "cli-cursor": "3.1.0",
@@ -20262,10 +20882,10 @@
         "enquirer": "~2.3.6",
         "figures": "3.2.0",
         "flat": "^5.0.2",
+        "front-matter": "^4.0.2",
         "fs-extra": "^11.1.0",
         "ignore": "^5.0.4",
         "jest-diff": "^29.4.1",
-        "js-yaml": "npm:@zkochan/js-yaml@0.0.7",
         "jsonc-parser": "3.2.0",
         "lines-and-columns": "~2.0.3",
         "minimatch": "9.0.3",
@@ -20288,16 +20908,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "19.0.7",
-        "@nx/nx-darwin-x64": "19.0.7",
-        "@nx/nx-freebsd-x64": "19.0.7",
-        "@nx/nx-linux-arm-gnueabihf": "19.0.7",
-        "@nx/nx-linux-arm64-gnu": "19.0.7",
-        "@nx/nx-linux-arm64-musl": "19.0.7",
-        "@nx/nx-linux-x64-gnu": "19.0.7",
-        "@nx/nx-linux-x64-musl": "19.0.7",
-        "@nx/nx-win32-arm64-msvc": "19.0.7",
-        "@nx/nx-win32-x64-msvc": "19.0.7"
+        "@nx/nx-darwin-arm64": "19.2.3",
+        "@nx/nx-darwin-x64": "19.2.3",
+        "@nx/nx-freebsd-x64": "19.2.3",
+        "@nx/nx-linux-arm-gnueabihf": "19.2.3",
+        "@nx/nx-linux-arm64-gnu": "19.2.3",
+        "@nx/nx-linux-arm64-musl": "19.2.3",
+        "@nx/nx-linux-x64-gnu": "19.2.3",
+        "@nx/nx-linux-x64-musl": "19.2.3",
+        "@nx/nx-win32-arm64-msvc": "19.2.3",
+        "@nx/nx-win32-x64-msvc": "19.2.3"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",
@@ -20310,6 +20930,18 @@
         "@swc/core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nx/node_modules/@zkochan/js-yaml": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz",
+      "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/nx/node_modules/brace-expansion": {
@@ -20331,18 +20963,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/nx/node_modules/js-yaml": {
-      "name": "@zkochan/js-yaml",
-      "version": "0.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/nx/node_modules/json5": {
@@ -28522,7 +29142,7 @@
     },
     "packages/visualizations": {
       "name": "@opendatasoft/visualizations",
-      "version": "0.24.1-beta.1",
+      "version": "0.24.1-beta.2",
       "license": "MIT",
       "dependencies": {
         "@placemarkio/geo-viewport": "^1.0.2",
@@ -28595,10 +29215,10 @@
     },
     "packages/visualizations-react": {
       "name": "@opendatasoft/visualizations-react",
-      "version": "0.24.1-beta.1",
+      "version": "0.24.1-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@opendatasoft/visualizations": "0.24.1-beta.1",
+        "@opendatasoft/visualizations": "0.24.1-beta.2",
         "use-callback-ref": "^1.2.4"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29142,7 +29142,7 @@
     },
     "packages/visualizations": {
       "name": "@opendatasoft/visualizations",
-      "version": "0.24.1-beta.2",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@placemarkio/geo-viewport": "^1.0.2",
@@ -29215,7 +29215,7 @@
     },
     "packages/visualizations-react": {
       "name": "@opendatasoft/visualizations-react",
-      "version": "0.24.1-beta.2",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@opendatasoft/visualizations": "0.24.1-beta.2",
@@ -29316,6 +29316,34 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "packages/visualizations-react/node_modules/@opendatasoft/visualizations": {
+      "version": "0.24.1-beta.2",
+      "resolved": "https://registry.npmjs.org/@opendatasoft/visualizations/-/visualizations-0.24.1-beta.2.tgz",
+      "integrity": "sha512-8eHi72CVjAakIT6bwCIc6ZBn38PE4moh5wL07yEUM7iIc9PmIHzXNAHaU2E26+baiBc15eWoK2vlZPJpAy6EQQ==",
+      "dependencies": {
+        "@placemarkio/geo-viewport": "^1.0.2",
+        "@turf/bbox": "^6.5.0",
+        "chart.js": "^4.4.2",
+        "chartjs-adapter-luxon": "^1.1.0",
+        "chartjs-chart-treemap": "^2.3.0",
+        "chartjs-plugin-datalabels": "^2.0.0",
+        "chartjs-plugin-stacked100": "^1.2.0",
+        "chroma-js": "^2.1.2",
+        "d3-geo": "^3.0.1",
+        "immutability-helper": "^3.1.1",
+        "lodash": "^4.17.21",
+        "luxon": "^2.5.0",
+        "maplibre-gl": "^3.6.2",
+        "markdown-it": "^12.0.4",
+        "markdown-it-link-attributes": "^3.0.0",
+        "markdown-it-mark": "^3.0.1",
+        "sass": "^1.70.0",
+        "tippy.js": "^6.3.7"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/visualizations-react/node_modules/@storybook/addon-actions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8180,7 +8180,6 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -9080,7 +9079,6 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9203,7 +9201,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -9695,7 +9692,6 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -13483,7 +13479,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -13976,7 +13971,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14415,7 +14409,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -15136,7 +15129,6 @@
     },
     "node_modules/immutable": {
       "version": "4.3.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-cwd": {
@@ -15477,7 +15469,6 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -15628,7 +15619,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15677,7 +15667,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -15751,7 +15740,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -19663,7 +19651,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21584,7 +21571,6 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -23243,7 +23229,6 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -24116,7 +24101,6 @@
     },
     "node_modules/sass": {
       "version": "1.71.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -24878,7 +24862,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -26155,7 +26138,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -28540,7 +28522,7 @@
     },
     "packages/visualizations": {
       "name": "@opendatasoft/visualizations",
-      "version": "0.24.1-beta.0",
+      "version": "0.24.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "@placemarkio/geo-viewport": "^1.0.2",
@@ -28559,6 +28541,7 @@
         "markdown-it": "^12.0.4",
         "markdown-it-link-attributes": "^3.0.0",
         "markdown-it-mark": "^3.0.1",
+        "sass": "^1.70.0",
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
@@ -28599,7 +28582,6 @@
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-svelte": "^6.1.0",
         "rollup-plugin-terser": "^7.0.2",
-        "sass": "^1.70.0",
         "svelte": "^3.43.2",
         "svelte-check": "^2.2.7",
         "svelte-eslint-parser": "^0.33.1",
@@ -28613,10 +28595,10 @@
     },
     "packages/visualizations-react": {
       "name": "@opendatasoft/visualizations-react",
-      "version": "0.24.1-beta.0",
+      "version": "0.24.1-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@opendatasoft/visualizations": "0.24.1-beta.0",
+        "@opendatasoft/visualizations": "0.24.1-beta.1",
         "use-callback-ref": "^1.2.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "lerna": "^8.1.2",
-    "nx": "^19.0.7"
+    "nx": "^19.2.3"
   },
   "dependencies": {
     "-": "^0.0.1"

--- a/packages/visualizations-react/LICENSE
+++ b/packages/visualizations-react/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 Opendatasoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations-react",
-    "version": "0.24.1-beta.0",
+    "version": "0.24.1-beta.1",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",
@@ -52,7 +52,7 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
-        "@opendatasoft/visualizations": "0.24.1-beta.0",
+        "@opendatasoft/visualizations": "0.24.1-beta.1",
         "use-callback-ref": "^1.2.4"
     },
     "devDependencies": {

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations-react",
-    "version": "0.24.1",
+    "version": "0.24.1-beta.0",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",
@@ -52,7 +52,7 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
-        "@opendatasoft/visualizations": "0.24.1",
+        "@opendatasoft/visualizations": "0.24.1-beta.0",
         "use-callback-ref": "^1.2.4"
     },
     "devDependencies": {

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations-react",
-    "version": "0.24.1-beta.2",
+    "version": "0.25.0",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -114,5 +114,5 @@
         "tslib": "^2.1.0",
         "typescript": "4.6"
     },
-    "gitHead": "d8439e859fbc458019572f50ac920e367719476a"
+    "gitHead": "5b28cc594764f53129f0de5847152dd55e27ab24"
 }

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations-react",
-    "version": "0.24.1-beta.1",
+    "version": "0.24.1-beta.2",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",
@@ -52,7 +52,7 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
-        "@opendatasoft/visualizations": "0.24.1-beta.1",
+        "@opendatasoft/visualizations": "0.24.1-beta.2",
         "use-callback-ref": "^1.2.4"
     },
     "devDependencies": {

--- a/packages/visualizations/LICENSE
+++ b/packages/visualizations/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 Opendatasoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations",
-    "version": "0.24.1-beta.1",
+    "version": "0.24.1-beta.2",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",
@@ -104,8 +104,8 @@
         "markdown-it": "^12.0.4",
         "markdown-it-link-attributes": "^3.0.0",
         "markdown-it-mark": "^3.0.1",
-        "tippy.js": "^6.3.7",
-        "sass": "^1.70.0"
+        "sass": "^1.70.0",
+        "tippy.js": "^6.3.7"
     },
     "gitHead": "5b28cc594764f53129f0de5847152dd55e27ab24"
 }

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -80,7 +80,6 @@
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-svelte": "^6.1.0",
         "rollup-plugin-terser": "^7.0.2",
-        "sass": "^1.70.0",
         "svelte": "^3.43.2",
         "svelte-check": "^2.2.7",
         "svelte-eslint-parser": "^0.33.1",
@@ -105,7 +104,8 @@
         "markdown-it": "^12.0.4",
         "markdown-it-link-attributes": "^3.0.0",
         "markdown-it-mark": "^3.0.1",
-        "tippy.js": "^6.3.7"
+        "tippy.js": "^6.3.7",
+        "sass": "^1.70.0"
     },
     "gitHead": "5b28cc594764f53129f0de5847152dd55e27ab24"
 }

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations",
-    "version": "0.24.1-beta.0",
+    "version": "0.24.1-beta.1",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations",
-    "version": "0.24.1",
+    "version": "0.24.1-beta.0",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -21,6 +21,7 @@
     "module": "dist/index.es.js",
     "types": "dist/index.d.ts",
     "styles": "dist/index.css",
+    "svelte": "src/index.ts",
     "scripts": {
         "prepare": "rimraf dist && rollup --config",
         "build": "rollup --config",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -106,5 +106,6 @@
         "markdown-it-link-attributes": "^3.0.0",
         "markdown-it-mark": "^3.0.1",
         "tippy.js": "^6.3.7"
-    }
+    },
+    "gitHead": "5b28cc594764f53129f0de5847152dd55e27ab24"
 }

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations",
-    "version": "0.24.1-beta.2",
+    "version": "0.25.0",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",

--- a/packages/visualizations/src/components/Chart/index.ts
+++ b/packages/visualizations/src/components/Chart/index.ts
@@ -1,15 +1,15 @@
-import * as ChartJs from 'chart.js';
+import ChartJs, { Chart as ChartModule, registerables } from 'chart.js';
 import { TreemapController, TreemapElement } from 'chartjs-chart-treemap';
-import ChartDataLabels from 'chartjs-plugin-datalabels';
+import DataLabels from 'chartjs-plugin-datalabels';
 import Stacked100Plugin from 'chartjs-plugin-stacked100';
 import Chart from './Chart.svelte';
 import PieDataLabelsPlugin from './pieDataLabelsPlugin';
 
-ChartJs.Chart.register(...ChartJs.registerables);
-ChartJs.Chart.register(ChartDataLabels);
-ChartJs.Chart.register(PieDataLabelsPlugin);
-ChartJs.Chart.register(Stacked100Plugin);
-ChartJs.Chart.register(TreemapController, TreemapElement);
+ChartModule.register(...registerables);
+ChartModule.register(DataLabels);
+ChartModule.register(PieDataLabelsPlugin);
+ChartModule.register(Stacked100Plugin);
+ChartModule.register(TreemapController, TreemapElement);
 
 ChartJs.defaults.animation = false;
 
@@ -17,5 +17,5 @@ ChartJs.defaults.animation = false;
 // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
 export const _ChartJs = ChartJs;
 // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
-export const _ChartDataLabels = ChartDataLabels;
+export const _ChartDataLabels = DataLabels;
 export default Chart;

--- a/packages/visualizations/src/components/Chart/index.ts
+++ b/packages/visualizations/src/components/Chart/index.ts
@@ -1,4 +1,4 @@
-import ChartJs, { Chart as ChartModule, registerables } from 'chart.js';
+import { Chart as ChartModule, registerables, defaults } from 'chart.js';
 import { TreemapController, TreemapElement } from 'chartjs-chart-treemap';
 import DataLabels from 'chartjs-plugin-datalabels';
 import Stacked100Plugin from 'chartjs-plugin-stacked100';
@@ -11,11 +11,8 @@ ChartModule.register(PieDataLabelsPlugin);
 ChartModule.register(Stacked100Plugin);
 ChartModule.register(TreemapController, TreemapElement);
 
-ChartJs.defaults.animation = false;
+defaults.animation = false;
 
-// Export ChartJS to allow reusing instance and changing default, use case not supported
-// eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
-export const _ChartJs = ChartJs;
 // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
 export const _ChartDataLabels = DataLabels;
 export default Chart;

--- a/packages/visualizations/src/components/Map/Svg/Map.svelte
+++ b/packages/visualizations/src/components/Map/Svg/Map.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import { geoPath, GeoProjection } from 'd3-geo';
+    import { geoPath } from 'd3-geo';
+    import type { GeoProjection } from 'd3-geo';
     import type { Feature, FeatureCollection } from 'geojson';
     import type { SvgPropertyMapping } from './types';
 

--- a/packages/visualizations/src/index.ts
+++ b/packages/visualizations/src/index.ts
@@ -1,4 +1,4 @@
-export { default as Chart, _ChartJs, _ChartDataLabels } from './components/Chart';
+export { default as Chart, _ChartDataLabels } from './components/Chart';
 export { default as MarkdownText } from './components/MarkdownText';
 export { default as KpiCard } from './components/KpiCard';
 export { ChoroplethGeoJson, ChoroplethVectorTiles } from './components/Map/WebGl';


### PR DESCRIPTION
## Summary

The goal for this PR is to export Svelte uncompiled components, so that they can be used **in a SvelteKit app**

### Changes
I added a `svelte` field in package.json

`exports: { ".": { "import": …; "svelte": …; }` seems to confuse rollup and vite (contrary to what the doc suggests). It's be explored in further tests though, this is the right way to export both ESM and umd, something that has been troublesome.

The explicit import of `registerable` is to avoid tree shaking. I deleted the export the namespace since we actually don't use it, I don't think it had been tested that it worked and was messing up with explicit imports.

### Changelog
It's now possible to import svelte uncompiled components to be used in a Svelte app: 
```
<script>
import { Chart } from '@opendatasoft/visualizations';
</script>

<Chart {data} {options} />
```

## Open discussion & test method
Soooooo… hardest one liner of my life. So trick is to have ChartJs work with both SSR and Treeshaking

To test if it's working, create a SvelteKit app and install visiualizations:
```
npm create svelte@latest my-app
cd my-app
npm install
npm install --save @opendatasoft/visualizations@0.24.1-beta.1
npm run dev -- --open
```

And try to create char. @fpassaniti you can find `data` and `options` to try with [here](https://616594e84c1692003af430f3-jombspzrzd.chromatic.com/?path=/docs/chart-axisassemblages--docs)