### PR TITLE
[FIX][TABLE][SC-50479] Update page size

### DIFF
--- a/packages/visualizations/src/components/Pagination/PageSize.svelte
+++ b/packages/visualizations/src/components/Pagination/PageSize.svelte
@@ -17,7 +17,7 @@
     }
 </script>
 
-<select bind:value on:change={(e) => onChange(toNumber(e.currentTarget.value))}>
+<select bind:value on:input={(e) => onChange(toNumber(e.currentTarget.value))}>
     {#each options as option}
         <option label={option.label} value={option.value} />
     {/each}


### PR DESCRIPTION
## Summary

The goal for this PR is to fix the behavior for the page size select as it can't be used on Chrome/Safari

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-50479](https://app.shortcut.com/opendatasoft/story/50479).

### Changes
Use the `input` event instead of the `select`. I didn't dive into the why, but it does the job.

