### PR TITLE
fix: remove safari select style

### DIFF
--- a/packages/visualizations/src/components/Pagination/PageSize.svelte
+++ b/packages/visualizations/src/components/Pagination/PageSize.svelte
@@ -23,6 +23,8 @@
     {/each}
 </select>
 
+<!-- disabling max-len doesn't work in style block, so we turn it off here -->
+<!-- eslint-disable max-len -->
 <style>
     :global(.ods-dataviz--default) select {
         background-color: white;
@@ -30,5 +32,12 @@
         border: solid 1px var(--border-color);
         border-radius: var(--border-radius-2);
         width: fit-content;
+        /* remove all styles and re-add arrow to fix Safari appearance */
+        background: url('data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0Ljk1IDEwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2ZmZjt9LmNscy0ye2ZpbGw6IzQ0NDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmFycm93czwvdGl0bGU+PHJlY3QgY2xhc3M9ImNscy0xIiB3aWR0aD0iNC45NSIgaGVpZ2h0PSIxMCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxLjQxIDQuNjcgMi40OCAzLjE4IDMuNTQgNC42NyAxLjQxIDQuNjciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMy41NCA1LjMzIDIuNDggNi44MiAxLjQxIDUuMzMgMy41NCA1LjMzIi8+PC9zdmc+')
+            no-repeat 95% 50%;
+        -moz-appearance: none;
+        -webkit-appearance: none;
+        appearance: none;
+        padding-right: var(--spacing-100);
     }
 </style>


### PR DESCRIPTION
## Summary

The goal for this PR is to remove safari glossy style on the page size select

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-50489](https://app.shortcut.com/opendatasoft/story/50489).

### Changes
The solution is `-webkit-appearance: none` and readd the arrows as background image. The problem is, the background image is for all browsers, so we need to have `appearance: none;` globally.

This only applies to default style.

### Changelog
PageSize select doesn't have the default safari style anymore.

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [x] Tests coverage has improved
- [x] Code is ready for a release on NPM
