### PR TITLE
feat: add an empty state for the table

### DIFF
--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -77,3 +77,9 @@ Unstyled.args = {
     data,
     options: { ...options, unstyled: true },
 };
+
+export const emptyState = Template.bind({});
+emptyState.args = {
+    data: { value: [], loading: false },
+    options: { ...options, emptyStateLabel: 'Neniuj registroj trovitaj...' },
+};

--- a/packages/visualizations/src/components/Table/Body.svelte
+++ b/packages/visualizations/src/components/Table/Body.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <tbody>
-    {#if records.length === 0}
+    {#if records.length === 0 && !loadingRowsNumber}
         <tr>
             <td colspan={columns.length}>
                 <em>{emptyStateLabel}</em>

--- a/packages/visualizations/src/components/Table/Body.svelte
+++ b/packages/visualizations/src/components/Table/Body.svelte
@@ -4,9 +4,17 @@
 
     export let columns: Column[];
     export let records: TableData;
+    export let emptyStateLabel = 'No records found...';
 </script>
 
 <tbody>
+    {#if records.length === 0}
+        <tr>
+            <td colspan={columns.length}>
+                <em>{emptyStateLabel}</em>
+            </td>
+        </tr>
+    {/if}
     {#each records as record}
         <tr>
             {#each columns as column}
@@ -23,5 +31,11 @@
 
     :global(.ods-dataviz--default) tr:last-child {
         border-bottom: none;
+    }
+
+    :global(.ods-dataviz--default) em {
+        text-align: center;
+        width: 100%;
+        display: block;
     }
 </style>

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -8,6 +8,7 @@
     export let columns: Column[];
     export let records: DataFrame | undefined;
     export let description: string | undefined;
+    export let emptyStateLabel: string | undefined;
 
     const tableId = `table-${generateId()}`;
 </script>
@@ -16,7 +17,7 @@
     <table aria-describedby={description ? tableId : undefined}>
         <Headers {columns} />
         {#if records}
-            <Body {records} {columns} />
+            <Body {records} {columns} {emptyStateLabel} />
         {/if}
     </table>
 </div>

--- a/packages/visualizations/src/components/Table/TableCard.svelte
+++ b/packages/visualizations/src/components/Table/TableCard.svelte
@@ -21,6 +21,7 @@
         unstyled,
         locale: localeOption,
         pagination,
+        emptyStateLabel,
     } = options);
     $: $locale = localeOption || navigator.language;
     /* Preserves paginations controls positioning
@@ -30,7 +31,7 @@
 
 <Card {title} {subtitle} {source} defaultStyle={!unstyled}>
     <div>
-        <Table {records} {columns} {description} />
+        <Table {records} {columns} {description} {emptyStateLabel} />
         {#if pagination}
             <Pagination {...pagination} />
         {/if}

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -98,6 +98,7 @@ export type TableOptions = {
     title?: string;
     subtitle?: string;
     description?: string;
+    emptyStateLabel?: string;
     source?: Source;
     /** To format date and number with the right locale. Default is from browser language */
     locale?: string;


### PR DESCRIPTION
## Summary

The goal for this PR is to add a small phrase to indicate that no records were found—but appart from that the table hasn't crashed.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-50771](https://app.shortcut.com/opendatasoft/story/50771).

### Changes
I added another alternative render for the body, similar to the loading state.

I could have made it into it's own component, but I don't find the `Body.svelte` too cluttered for now. I'm totally open to it though.