### PR TITLE
chore: add scrollbox selector

### DIFF
--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -13,7 +13,7 @@
     const tableId = `table-${generateId()}`;
 </script>
 
-<div>
+<div class="scrollbox">
     <table aria-describedby={description ? tableId : undefined}>
         <Headers {columns} />
         {#if records}
@@ -31,7 +31,7 @@
         display: none;
     }
 
-    :global(.ods-dataviz--default) div {
+    :global(.ods-dataviz--default) .scrollbox {
         border: solid 1px var(--border-color);
         border-radius: var(--border-radius-2);
         overflow-x: auto;


### PR DESCRIPTION
## Summary

The goal for this PR is to add a scrollbox selector in order to override default styles (namely border radius in the Studio).

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-46294](https://app.shortcut.com/opendatasoft/story/46294).


