### PR TITLE
Add direction on the `Table` component

### DIFF
--- a/packages/visualizations-react/stories/Table/options.ts
+++ b/packages/visualizations-react/stories/Table/options.ts
@@ -82,6 +82,7 @@ const options: TableOptions = {
         href: '',
     },
     locale: 'fr',
+    direction: 'ltr',
 };
 
 export default options;

--- a/packages/visualizations/src/components/Table/Cell/Cell.svelte
+++ b/packages/visualizations/src/components/Table/Cell/Cell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { Column } from '../types';
     import Format, { isValidRawValue } from './Format';
+    import { isRtl } from '../store';
 
     export let rawValue: unknown;
     export let column: Column;
@@ -9,7 +10,7 @@
 </script>
 
 <!-- To display a format value, rawValue must be different from undefined or null -->
-<td class={`table-data--${dataFormat}`}>
+<td class="{`table-data--${dataFormat}`} {$isRtl ? 'rtl-direction' : ''}">
     {#if isValidRawValue(rawValue)}
         <svelte:component this={Format[dataFormat]} {rawValue} {...options} />
     {/if}
@@ -19,6 +20,10 @@
     :global(.ods-dataviz--default td) {
         text-align: left;
         padding: var(--spacing-75);
+    }
+
+    :global(.ods-dataviz--default td.rtl-direction) {
+        text-align: right;
     }
 
     :global(.ods-dataviz--default td.table-header--number) {

--- a/packages/visualizations/src/components/Table/Headers/Headers.svelte
+++ b/packages/visualizations/src/components/Table/Headers/Headers.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import SortButton from './SortButton.svelte';
+    import { isRtl } from '../store';
     import type { Column } from '../types';
 
     export let columns: Column[];
@@ -8,7 +9,7 @@
 <thead>
     <tr>
         {#each columns as column}
-            <th class={`table-header--${column.dataFormat}`}>
+            <th class="{`table-header--${column.dataFormat}`} {$isRtl ? 'rtl-direction' : ''}">
                 {#if column.onClick}
                     <SortButton
                         sorted={column?.sorted}
@@ -32,6 +33,10 @@
     :global(.ods-dataviz--default th) {
         text-align: left;
         padding: var(--spacing-75);
+    }
+
+    :global(.ods-dataviz--default th.rtl-direction) {
+        text-align: right;
     }
 
     :global(.ods-dataviz--default th.table-header--number) {

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -4,6 +4,7 @@
     import { generateId } from '../utils';
     import Headers from './Headers';
     import Body from './Body.svelte';
+    import { isRtl } from './store';
 
     export let loadingRowsNumber: number | null;
     export let columns: Column[];
@@ -14,7 +15,10 @@
 </script>
 
 <div>
-    <table aria-describedby={description ? tableId : undefined}>
+    <table
+        aria-describedby={description ? tableId : undefined}
+        class={$isRtl ? 'rtl-direction' : ''}
+    >
         <Headers {columns} />
         {#if records}
             <Body {loadingRowsNumber} {records} {columns} />
@@ -29,6 +33,10 @@
     /* Suitable for elements that are used via aria-describedby or aria-labelledby */
     .a11y-invisible-description {
         display: none;
+    }
+
+    .rtl-direction {
+        direction: rtl;
     }
 
     :global(.ods-dataviz--default) div {

--- a/packages/visualizations/src/components/Table/TableCard.svelte
+++ b/packages/visualizations/src/components/Table/TableCard.svelte
@@ -3,7 +3,8 @@
     import Table from './Table.svelte';
     import Pagination from '../Pagination/Pagination.svelte';
     import Card from '../utils/Card.svelte';
-    import { locale } from './store';
+    import { locale, direction, isRtl } from './store';
+    import { RTL_LANGUAGES_CODE } from './constants';
 
     // ensure exported type matches declared props
     type $$Props = TableProps;
@@ -20,10 +21,13 @@
         source,
         unstyled,
         locale: localeOption,
+        direction: directionOption,
         pagination,
     } = options);
     $: $locale = localeOption || navigator.language;
     $: defaultLoadingRowsNumber = pagination ? pagination.recordsPerPage : 5;
+    $: $direction = directionOption || (RTL_LANGUAGES_CODE.includes($locale) ? 'rtl' : 'ltr');
+    $: $isRtl = $direction === 'rtl';
     $: loadingRowsNumber = isLoading ? defaultLoadingRowsNumber : null;
     /* Preserves paginations controls positioning
     min heigh of table + controls = max-height of row * (number of rows) + headers + pagination

--- a/packages/visualizations/src/components/Table/constants.ts
+++ b/packages/visualizations/src/components/Table/constants.ts
@@ -7,3 +7,24 @@ export const DATA_FORMAT = {
     boolean: 'boolean',
     url: 'url',
 } as const;
+
+/* potential other rtl languages: ['iw', 'kd', 'pk'] */
+export const RTL_LANGUAGES_CODE = [
+    'ar',
+    'az',
+    'fa',
+    'he',
+    'jv',
+    'kk',
+    'ks',
+    'ku',
+    'ml',
+    'ms',
+    'ps',
+    'sd',
+    'so',
+    'tk',
+    'ug',
+    'ur',
+    'yi',
+] as string[];

--- a/packages/visualizations/src/components/Table/store.ts
+++ b/packages/visualizations/src/components/Table/store.ts
@@ -1,7 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 
 const defaultLocale = navigator.language;
+const defaultDirection = 'ltr';
 
 // eslint-disable-next-line import/prefer-default-export
 export const locale = writable<string>(defaultLocale);
+export const direction = writable<string>(defaultDirection);
+export const isRtl = writable<boolean>(get(direction) === 'rtl');

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -101,6 +101,8 @@ export type TableOptions = {
     source?: Source;
     /** To format date and number with the right locale. Default is from browser language */
     locale?: string;
+    /** To set the reading direction of the table (based on locale). Default is 'ltr' */
+    direction?: string;
     /**
      * Removes all the presentational styles.
      * Default is `false`.


### PR DESCRIPTION
## Summary

The goal for this PR is to change the reading direction in the `Table` component depending on a property.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-48044](https://app.shortcut.com/opendatasoft/story/48044/sdk-add-direction-rtl-to-table).

### Changes

Add a new property `direction` for `TableCard`.
Use 2 new stores: `direction` and `isRtl` to propagate the property in the component tree.

#### Breaking Changes

None

### Changelog

In the Table component: It's now possible to change the reading direction depending on the locale.

## To be tested

In storybook: change the `direction` value in `options`

## Review checklist

- [X] Description is complete
- [X] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [X] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [X] Code is ready for a release on NPM
