### PR TITLE
fix: upgrade linked version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29142,7 +29142,7 @@
     },
     "packages/visualizations": {
       "name": "@opendatasoft/visualizations",
-      "version": "0.25.0",
+      "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
         "@placemarkio/geo-viewport": "^1.0.2",
@@ -29215,10 +29215,10 @@
     },
     "packages/visualizations-react": {
       "name": "@opendatasoft/visualizations-react",
-      "version": "0.25.0",
+      "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
-        "@opendatasoft/visualizations": "^0.25.0",
+        "@opendatasoft/visualizations": "^0.24.1",
         "use-callback-ref": "^1.2.4"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29218,7 +29218,7 @@
       "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
-        "@opendatasoft/visualizations": "0.24.1-beta.2",
+        "@opendatasoft/visualizations": "^0.25.0",
         "use-callback-ref": "^1.2.4"
       },
       "devDependencies": {
@@ -29316,34 +29316,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/visualizations-react/node_modules/@opendatasoft/visualizations": {
-      "version": "0.24.1-beta.2",
-      "resolved": "https://registry.npmjs.org/@opendatasoft/visualizations/-/visualizations-0.24.1-beta.2.tgz",
-      "integrity": "sha512-8eHi72CVjAakIT6bwCIc6ZBn38PE4moh5wL07yEUM7iIc9PmIHzXNAHaU2E26+baiBc15eWoK2vlZPJpAy6EQQ==",
-      "dependencies": {
-        "@placemarkio/geo-viewport": "^1.0.2",
-        "@turf/bbox": "^6.5.0",
-        "chart.js": "^4.4.2",
-        "chartjs-adapter-luxon": "^1.1.0",
-        "chartjs-chart-treemap": "^2.3.0",
-        "chartjs-plugin-datalabels": "^2.0.0",
-        "chartjs-plugin-stacked100": "^1.2.0",
-        "chroma-js": "^2.1.2",
-        "d3-geo": "^3.0.1",
-        "immutability-helper": "^3.1.1",
-        "lodash": "^4.17.21",
-        "luxon": "^2.5.0",
-        "maplibre-gl": "^3.6.2",
-        "markdown-it": "^12.0.4",
-        "markdown-it-link-attributes": "^3.0.0",
-        "markdown-it-mark": "^3.0.1",
-        "sass": "^1.70.0",
-        "tippy.js": "^6.3.7"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/visualizations-react/node_modules/@storybook/addon-actions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29218,7 +29218,7 @@
       "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
-        "@opendatasoft/visualizations": "^0.24.1",
+        "@opendatasoft/visualizations": "0.24.1",
         "use-callback-ref": "^1.2.4"
       },
       "devDependencies": {

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations-react",
-    "version": "0.25.0",
+    "version": "0.24.1",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",
@@ -52,7 +52,7 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
-        "@opendatasoft/visualizations": "^0.25.0",
+        "@opendatasoft/visualizations": "^0.24.1",
         "use-callback-ref": "^1.2.4"
     },
     "devDependencies": {

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -52,7 +52,7 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
-        "@opendatasoft/visualizations": "0.24.1-beta.2",
+        "@opendatasoft/visualizations": "^0.25.0",
         "use-callback-ref": "^1.2.4"
     },
     "devDependencies": {

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -52,7 +52,7 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
-        "@opendatasoft/visualizations": "^0.24.1",
+        "@opendatasoft/visualizations": "0.24.1",
         "use-callback-ref": "^1.2.4"
     },
     "devDependencies": {

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations",
-    "version": "0.25.0",
+    "version": "0.24.1",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",


### PR DESCRIPTION
## Summary

The goal for this PR is to fix the dependency version of @opendatasoft/visualizations in visualizations-react that wasn't correctly updated due to a manual update of versions.
