### PR TITLE
Chore/update actions

### DIFF
--- a/.github/workflows/api-client.yml
+++ b/.github/workflows/api-client.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: ./packages/api-client
 
       - name: Comment
-        uses: romeovs/lcov-reporter-action@v0.4
+        uses: romeovs/lcov-reporter-action@v0.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: ./packages/api-client/coverage/lcov.info

--- a/.github/workflows/api-client.yml
+++ b/.github/workflows/api-client.yml
@@ -8,22 +8,17 @@ on:
       - main
 jobs:
   build:
-    name: Get api client test coverage on node ${{ matrix.node }} and ${{ matrix.os }}
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node: ["18.x", "20.x"]
-        os: [ubuntu-latest]
+    name: Get api client test coverage
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Use Node ${{ matrix.node }}
+      - name: Use Node 20
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '20.x'
 
       - name: Install
         run: npm ci

--- a/.github/workflows/api-client.yml
+++ b/.github/workflows/api-client.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
@@ -38,7 +38,7 @@ jobs:
         working-directory: ./packages/api-client
 
       - name: Comment
-        uses: romeovs/lcov-reporter-action@v0.2.19
+        uses: romeovs/lcov-reporter-action@v0.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: ./packages/api-client/coverage/lcov.info

--- a/.github/workflows/visualizations.yml
+++ b/.github/workflows/visualizations.yml
@@ -65,10 +65,6 @@ jobs:
   chromatic-deployment:
     if: github.event.pull_request.draft == false || github.ref_name == 'main'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: ["18.x", "20.x"]
-
     needs: [test, lint]
     
     steps:
@@ -77,10 +73,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node ${{ matrix.node }}
+      - name: Use Node 20
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '20.x'
 
       - name: Build
         run: npm run build-ci

--- a/.github/workflows/visualizations.yml
+++ b/.github/workflows/visualizations.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
@@ -73,12 +73,12 @@ jobs:
     
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -1,4 +1,4 @@
-# @opendatasoft/api-client ![CI status](https://github.com/opendatasoft/ods-dataviz-sdk/workflows/CI/badge.svg)
+# @opendatasoft/api-client test ![CI status](https://github.com/opendatasoft/ods-dataviz-sdk/workflows/CI/badge.svg)
 
 This package implements a Typescript/Javascript client library for [Opendatasoft's Explore API v2.1](https://help.opendatasoft.com/apis/ods-explore-v2/explore_v2.1.html).
 

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -1,4 +1,4 @@
-# @opendatasoft/api-client test ![CI status](https://github.com/opendatasoft/ods-dataviz-sdk/workflows/CI/badge.svg)
+# @opendatasoft/api-client ![CI status](https://github.com/opendatasoft/ods-dataviz-sdk/workflows/CI/badge.svg)
 
 This package implements a Typescript/Javascript client library for [Opendatasoft's Explore API v2.1](https://help.opendatasoft.com/apis/ods-explore-v2/explore_v2.1.html).
 

--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -101,7 +101,7 @@ emptyState.args = {
 export const RtlDirection = Template.bind({});
 RtlDirection.parameters = {
     direction: 'rtl',
-    disableSnapshot: true,
+    chromatic: { disableSnapshot: true },
 };
 RtlDirection.args = {
     data,


### PR DESCRIPTION
## Summary

The goal for this PR is to update version of github actions we used in our CI. 
Currently we have warnings about incompatible Node version requirement 

**Before**
![image](https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/dea70302-a15d-4524-9e62-2bcfb9ed17e9)


**After**

![image](https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/b0c43a31-6151-40f0-b990-f523b9fd274d)

--- 

![image](https://github.com/opendatasoft/ods-dataviz-sdk/assets/117300300/a98437de-ae0f-421d-ba51-782aec9e1c4e)


Also
- [removed a table Story from Chromatic](https://github.com/opendatasoft/ods-dataviz-sdk/pull/255/commits/9cf57981dfcad38fdc6e5a0f6db340256fb9722f) as the RTL addon we just added doesn't apply on the chromatic snapshot.
- publish Chromatic snapshots only with Node 20


(Internal for Opendatasoft only) Associated Shortcut ticket: 🏴‍☠️ 

