### PR TITLE
feat(api-client): add getParams method to Query class

### DIFF
--- a/packages/api-client/src/odsql/index.ts
+++ b/packages/api-client/src/odsql/index.ts
@@ -17,6 +17,10 @@ export class Query {
         this.path = path;
     }
 
+    getParams(): Record<string, string | string[]> {
+        return this.params;
+    }
+
     getPath(): string {
         return this.path;
     }


### PR DESCRIPTION
## Summary

The goal for this PR is to add a getParams method for the Query class : 

Use case:  I need to recreate a new OdsqlQuery and want to use the existing params from a first known query one by one.

## Open discussion

Is there an alternative way to achieve my use case ?

Was there a good reason not to implement this method at the beginning ?

