### PR TITLE
[STYLE][TABLE]: "no records" label is always visible

### DIFF
--- a/packages/visualizations/src/components/Table/Body.svelte
+++ b/packages/visualizations/src/components/Table/Body.svelte
@@ -1,20 +1,17 @@
 <script lang="ts">
     import type { Column, TableData } from './types';
     import Cell, { LoadingCell } from './Cell';
+    import EmptyRow from './EmptyRow.svelte';
 
     export let loadingRowsNumber: number | null;
     export let columns: Column[];
     export let records: TableData | undefined;
-    export let emptyStateLabel = 'No records found...';
+    export let emptyStateLabel: string | undefined;
 </script>
 
 <tbody>
     {#if records?.length === 0 && !loadingRowsNumber}
-        <tr>
-            <td colspan={columns.length}>
-                <em>{emptyStateLabel}</em>
-            </td>
-        </tr>
+        <EmptyRow label={emptyStateLabel} />
     {/if}
     {#if loadingRowsNumber}
         {#each Array(loadingRowsNumber) as _}
@@ -42,11 +39,5 @@
 
     :global(.ods-dataviz--default) tr:last-child {
         border-bottom: none;
-    }
-
-    :global(.ods-dataviz--default) em {
-        text-align: center;
-        width: 100%;
-        display: block;
     }
 </style>

--- a/packages/visualizations/src/components/Table/EmptyRow.svelte
+++ b/packages/visualizations/src/components/Table/EmptyRow.svelte
@@ -3,9 +3,9 @@
 </script>
 
 <tr>
-    <div>
+    <td>
         <em>{label}</em>
-    </div>
+    </td>
 </tr>
 
 <style lang="scss">
@@ -13,7 +13,8 @@
     tr {
         height: $row-height;
     }
-    div {
+    td {
+        box-sizing: border-box;
         position: absolute;
         left: 0;
         right: 0;

--- a/packages/visualizations/src/components/Table/EmptyRow.svelte
+++ b/packages/visualizations/src/components/Table/EmptyRow.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+    export let label = 'No records found...';
+</script>
+
+<tr>
+    <div>
+        <em>{label}</em>
+    </div>
+</tr>
+
+<style lang="scss">
+    $row-height: 48px;
+    tr {
+        height: $row-height;
+    }
+    div {
+        position: absolute;
+        left: 0;
+        right: 0;
+        height: $row-height;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+</style>

--- a/packages/visualizations/src/components/Table/TableCard.svelte
+++ b/packages/visualizations/src/components/Table/TableCard.svelte
@@ -47,6 +47,7 @@
         margin-bottom: var(--spacing-100);
         overflow: hidden;
         background-color: var(--background-color);
+        position: relative;
     }
     :global(.ods-dataviz--default) div {
         max-width: 100%;


### PR DESCRIPTION
## Summary

The goal of this PR is to fix an issue where "no records" is not visible in a large table with a scroll section. Currently, having "no results" renders the table with a 'void' row, making it appear broken.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-51257](https://app.shortcut.com/opendatasoft/story/51257).

### Changes
Update the Empty part


## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
