### PR TITLE
[FIX][API-CLIENT] Update dataset exports formats

### DIFF
--- a/packages/api-client/src/client/constants.ts
+++ b/packages/api-client/src/client/constants.ts
@@ -25,6 +25,10 @@ export const EXPORT_DATASET_FORMAT = {
     TURTLE: 'turtle',
     N3: 'n3',
     MVT: 'mvt',
+    PARQUET: 'parquet',
+    FGB: 'fgb',
+    GPX: 'gpx',
+    ICAL: 'ical',
 } as const;
 
 export const EXPORT_CATALOG_FORMAT = {


### PR DESCRIPTION
## Summary

The goal for this PR is to add new dataset export formats

- geographic formats: fgb, gpx and parquet
- calendar format: ical

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-51661](https://app.shortcut.com/opendatasoft/story/51661).
