### PR TITLE
fix(Table): Delay map initialization to the tooltip creation

### DIFF
--- a/packages/visualizations/src/components/Table/Cell/Format/GeoFormat.svelte
+++ b/packages/visualizations/src/components/Table/Cell/Format/GeoFormat.svelte
@@ -29,10 +29,10 @@
         delay: [500, 0],
         duration: [275, 0],
         maxWidth: 'none',
-        onTrigger: () => {
+        onShow: () => {
             showMap = true;
         },
-        onUntrigger: () => {
+        onHide: () => {
             showMap = false;
         },
     }}


### PR DESCRIPTION
## Summary

The goal for this PR is to prevent Maplibre instances being created by merely passign the mouse over a cell (or tens of them if you pass your cursor through a page).

(Internal for Opendatasoft only) Associated Shortcut ticket: https://app.shortcut.com/opendatasoft/story/53245/table-don-t-create-the-map-immediately-on-hover

### Changes
The map initialization was hooked to `onTrigger` which is defined as "Invoked once the tippy has been triggered by a DOM event (e.g. mouseenter).".

The PR uses `onShow`  instead ("Invoked once the tippy begins to show.") which takes the delay into account, so that you need to have the mouse over the cell for 500ms before Maplibre starts running.

Same logic for the map destruction which uses its mirror callback `onHide`.

Tippy doc: https://atomiks.github.io/tippyjs/v6/all-props/#onshow

#### Breaking Changes

There may be a slight visual delay that wasn't here now, but you have to really look for it. This seems to be an acceptable compromise here.

### Changelog

In tables, Geo cells now initialized their underlying Maplibre map after the intended 500ms delay.


## To be tested
Are the tooltips properly created?
Is the map only created if you really want to see the tooltip?

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [x] Code is ready for a release on NPM
