### PR TITLE
feat(WebGlMap): Export the component from the packages

### DIFF
--- a/packages/visualizations-react/src/index.ts
+++ b/packages/visualizations-react/src/index.ts
@@ -9,6 +9,7 @@ import {
     ChoroplethSvg as _ChoroplethSvg,
     PoiMap as _PoiMap,
     Table as _Table,
+    WebGlMap as _WebGlMap,
 } from '@opendatasoft/visualizations';
 import type {
     ChartProps,
@@ -17,6 +18,7 @@ import type {
     ChoroplethGeoJsonProps,
     ChoroplethVectorTilesProps,
     PoiMapProps,
+    WebGlMapProps,
     TableProps,
 } from '@opendatasoft/visualizations';
 import reactifySvelte from 'reactify';
@@ -40,4 +42,5 @@ export const ChoroplethSvg = reactifySvelte<ChoroplethGeoJsonProps>(
     'ods-visualizations-choropleth-svg'
 );
 export const PoiMap = reactifySvelte<PoiMapProps>(_PoiMap, 'ods-visualizations-poi-map');
+export const WebGlMap = reactifySvelte<WebGlMapProps>(_WebGlMap, 'ods-visualizations-webgl-map');
 export const Table = reactifySvelte<TableProps>(_Table, 'ods-visualizations-table');

--- a/packages/visualizations/src/components/Map/WebGl/types.ts
+++ b/packages/visualizations/src/components/Map/WebGl/types.ts
@@ -144,3 +144,8 @@ export type Images = Record<
     string,
     { id: string; url: string; options?: Partial<StyleImageMetadata> }
 >;
+
+export type WebGlMapProps = {
+    data: WebGlMapData;
+    options: WebGlMapOptions;
+};


### PR DESCRIPTION
## Summary

The goal for this PR is to expose the `Map/WebGl` component and required types through the `visualizations-react` package.

### Changes

Since the component has a large value by itself, outside of its specialized `Poi` implementation, it makes sense to expose it as well. We're starting to use it natively in our platform.

#### Breaking Changes
None

### Changelog
The `WebGl` map component is now exported publicly from the `visualizations-react` package, as well as the types it requires for proper usage.


## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
