### PR TITLE
feat(api-client): add semantic_type to DatasetField

### DIFF
--- a/packages/api-client/src/client/constants.ts
+++ b/packages/api-client/src/client/constants.ts
@@ -12,6 +12,11 @@ export const ODS_DATASET_FIELD_TYPE = {
     JSON: 'json',
 } as const;
 
+export const ODS_DATASET_FIELD_SEMANTIC_TYPE = {
+    IP_ADDRESS: 'ip_address',
+    MONITORING_IP_ADDRESS: 'monitoring_ip_address',
+} as const;
+
 export const EXPORT_DATASET_FORMAT = {
     JSON: 'json',
     GEOJSON: 'geojson',

--- a/packages/api-client/src/client/types.ts
+++ b/packages/api-client/src/client/types.ts
@@ -1,7 +1,7 @@
 // Type hints for Api response
 
 import { ValueOf } from '../utils';
-import { EXPORT_CATALOG_FORMAT, EXPORT_DATASET_FORMAT, ODS_DATASET_FIELD_TYPE } from './constants';
+import { EXPORT_CATALOG_FORMAT, EXPORT_DATASET_FORMAT, ODS_DATASET_FIELD_TYPE, ODS_DATASET_FIELD_SEMANTIC_TYPE } from './constants';
 
 export interface Facet {
     name: string;
@@ -27,6 +27,8 @@ interface DataWithLinks {
 
 export type DatasetFieldType = ValueOf<typeof ODS_DATASET_FIELD_TYPE>;
 
+export type DatasetFieldSemanticType = ValueOf<typeof ODS_DATASET_FIELD_SEMANTIC_TYPE>;
+
 export interface DatasetAttachement {
     id: string;
     mimetype: string;
@@ -43,6 +45,7 @@ export interface DatasetField {
     name: string;
     label: string;
     type: DatasetFieldType;
+    semantic_type?: DatasetFieldSemanticType;
     annotations: unknown;
 }
 


### PR DESCRIPTION
## Summary

The goal for this PR is to add a new optional `semantic_type` property to dataset fields, to mirror this new feature in the API.

### Changes
This new property is optional (the API only mentions it if it exists, otherwise it doesn't appear in the schema at all).
I added the two current values existing in the platform's backend.

#### Breaking Changes
None

### Changelog
In the API Client: The `DatasetField` type now includes the optional `semantic_type` which can be returned by the API for fields that are using a semantic type such as "IP Address". A semantic type is a higher-level type with specific behaviors.


## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
