### PR TITLE
chore: scope sticky stores

### DIFF
--- a/packages/visualizations/src/components/Table/Cell/Td.svelte
+++ b/packages/visualizations/src/components/Table/Cell/Td.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
-    import { isHorizontallyScrolled, stickyColumnsOffset } from '../store';
-    import type { Column } from '../types';
+    import { getContext } from 'svelte';
+    import type { StickyStores, Column } from '../types';
     import { getStickyClasses, getStickyOffset } from '../sticky';
     import { HOVER_COLUMN_KEY } from '../constants';
 
     export let column: Column | null = null;
+
+    const { isHorizontallyScrolled, stickyColumnsOffset, lastStickyColumn } =
+        getContext<StickyStores>('sticky-stores');
 </script>
 
 <!-- To display a format value, rawValue must be different from undefined or null -->
 <td
     style={getStickyOffset($stickyColumnsOffset.get(column?.key || HOVER_COLUMN_KEY))}
-    class={getStickyClasses({ column, scrolled: $isHorizontallyScrolled })}
+    class={getStickyClasses({
+        column,
+        scrolled: $isHorizontallyScrolled,
+        lastStickyColumn: $lastStickyColumn,
+    })}
     class:button-cell={!column}
 >
     <slot />

--- a/packages/visualizations/src/components/Table/Headers/Th.svelte
+++ b/packages/visualizations/src/components/Table/Headers/Th.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
-    import type { Column } from '../types';
-    import { stickyColumnsWidth, stickyColumnsOffset, isHorizontallyScrolled } from '../store';
+    import { getContext } from 'svelte';
+    import type { StickyStores, Column } from '../types';
     import { getStickyClasses, getStickyOffset } from '../sticky';
     import { HOVER_COLUMN_KEY } from '../constants';
     import SortButton from './SortButton.svelte';
 
     export let column: Column | null = null;
+
+    const { stickyColumnsWidth, stickyColumnsOffset, isHorizontallyScrolled, lastStickyColumn } =
+        getContext<StickyStores>('sticky-stores');
 
     let thElement: HTMLElement;
     let clientWidth: number;
@@ -30,6 +33,7 @@
         class={`table-header--${column?.dataFormat || 'hover'} ${getStickyClasses({
             column,
             scrolled: $isHorizontallyScrolled,
+            lastStickyColumn: $lastStickyColumn,
         })}`}
     >
         {#if column.onClick}
@@ -48,7 +52,11 @@
     <th
         bind:this={thElement}
         style={getStickyOffset($stickyColumnsOffset.get(colKey))}
-        class={`button-cell ${getStickyClasses({ column, scrolled: $isHorizontallyScrolled })}`}
+        class={`button-cell ${getStickyClasses({
+            column,
+            scrolled: $isHorizontallyScrolled,
+            lastStickyColumn: $lastStickyColumn,
+        })}`}
     />
 {/if}
 

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+    import { setContext } from 'svelte';
     import type { DataFrame } from 'types';
     import { generateId } from 'components/utils';
     import type { Column, RowProps } from './types';
     import Headers from './Headers';
     import Body from './Body.svelte';
-    import { stickyColumnsWidth, isHorizontallyScrolled } from './store';
     import { HOVER_COLUMN_KEY } from './constants';
+    import { createStickyStores } from './store';
 
     export let loadingRowsNumber: number | null;
     export let columns: Column[];
@@ -18,6 +19,16 @@
 
     let scrollBox: HTMLDivElement;
     let sortedStickyColumns: Column[] = [];
+
+    const { stickyColumnsOffset, stickyColumnsWidth, lastStickyColumn, isHorizontallyScrolled } =
+        createStickyStores();
+
+    setContext('sticky-stores', {
+        stickyColumnsOffset,
+        stickyColumnsWidth,
+        lastStickyColumn,
+        isHorizontallyScrolled,
+    });
 
     function handleScroll() {
         $isHorizontallyScrolled =

--- a/packages/visualizations/src/components/Table/sticky.ts
+++ b/packages/visualizations/src/components/Table/sticky.ts
@@ -1,25 +1,25 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { get } from 'svelte/store';
 import { isNil } from 'lodash';
-import type { Column } from './types';
-import { lastStickyColumn } from './store';
+import type { Column, ColumnKey } from './types';
 import { HOVER_COLUMN_KEY } from './constants';
 
 export const getStickyClasses = ({
     column,
     scrolled,
+    lastStickyColumn,
 }: {
     column: Column | null;
     scrolled: boolean;
+    lastStickyColumn?: ColumnKey;
 }) => {
     if (!column) {
         return `sticky 
-        ${HOVER_COLUMN_KEY === get(lastStickyColumn) ? 'isLastSticky' : ''}
+        ${HOVER_COLUMN_KEY === lastStickyColumn ? 'isLastSticky' : ''}
         ${scrolled ? 'isHorizontallyScrolled' : ''}`;
     }
     return `
     ${column.sticky ? 'sticky' : ''}
-    ${column.key === get(lastStickyColumn) ? 'isLastSticky' : ''}
+    ${column.key === lastStickyColumn ? 'isLastSticky' : ''}
     ${scrolled ? 'isHorizontallyScrolled' : ''}
   `.trim();
 };

--- a/packages/visualizations/src/components/Table/store.ts
+++ b/packages/visualizations/src/components/Table/store.ts
@@ -7,36 +7,43 @@ const defaultLocale = navigator.language;
 export const locale = writable<string>(defaultLocale);
 export const debugWarnings = writable<boolean>(false);
 
-const newOffsetMap = () => new Map<string | typeof HOVER_COLUMN_KEY, number>();
+export const createStickyStores = () => {
+    const newOffsetMap = () => new Map<string | typeof HOVER_COLUMN_KEY, number>();
 
-const createWidths = () => {
-    const { update, set, subscribe } = writable(newOffsetMap());
-    return {
-        updateColumn: (key: string | typeof HOVER_COLUMN_KEY, width: number) =>
-            update(($widths) => {
-                $widths.set(key, width);
-                return $widths;
-            }),
-        reset: () => set(newOffsetMap()),
-        subscribe,
+    const createWidths = () => {
+        const { update, set, subscribe } = writable(newOffsetMap());
+        return {
+            updateColumn: (key: string | typeof HOVER_COLUMN_KEY, width: number) =>
+                update(($widths) => {
+                    $widths.set(key, width);
+                    return $widths;
+                }),
+            reset: () => set(newOffsetMap()),
+            subscribe,
+        };
     };
-};
-export const stickyColumnsWidth = createWidths();
+    const stickyColumnsWidth = createWidths();
 
-export const stickyColumnsOffset = derived(stickyColumnsWidth, ($widths) => {
-    const cumulativeWidths = newOffsetMap();
-    let cumulativeOffset = 0;
+    const stickyColumnsOffset = derived(stickyColumnsWidth, ($widths) => {
+        const cumulativeWidths = newOffsetMap();
+        let cumulativeOffset = 0;
 
-    Array.from($widths).forEach(([key, clientWidth]) => {
-        cumulativeWidths.set(key, cumulativeOffset);
-        cumulativeOffset += clientWidth + 1;
+        Array.from($widths).forEach(([key, clientWidth]) => {
+            cumulativeWidths.set(key, cumulativeOffset);
+            cumulativeOffset += clientWidth + 1;
+        });
+
+        return cumulativeWidths;
     });
 
-    return cumulativeWidths;
-});
+    const lastStickyColumn = derived(stickyColumnsWidth, ($widths) => [...$widths.keys()].at(-1));
 
-export const lastStickyColumn = derived(stickyColumnsWidth, ($widths) =>
-    [...$widths.keys()].at(-1)
-);
+    const isHorizontallyScrolled = writable(false);
 
-export const isHorizontallyScrolled = writable(false);
+    return {
+        stickyColumnsOffset,
+        stickyColumnsWidth,
+        lastStickyColumn,
+        isHorizontallyScrolled,
+    };
+};

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -1,4 +1,6 @@
 import type { Async, DataFrame, Source } from 'types';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type { Readable, Writable } from 'svelte/store';
 import type {
     BooleanFormatProps,
     DateFormatProps,
@@ -8,7 +10,7 @@ import type {
     URLFormatProps,
 } from '../Format/types';
 import type { Pagination } from '../Pagination/types';
-import type { DATA_FORMAT } from './constants';
+import type { DATA_FORMAT, HOVER_COLUMN_KEY } from './constants';
 
 export type GenericRecord = Record<string, unknown>; // avoid {} with no key from object;
 
@@ -108,4 +110,15 @@ export type TableOptions = {
 export type TableProps = {
     data: Async<TableData>;
     options: TableOptions;
+};
+
+export type ColumnKey = string | typeof HOVER_COLUMN_KEY;
+export type StickyStores = {
+    stickyColumnsWidth: Writable<Map<ColumnKey, number>> & {
+        updateColumn: (key: ColumnKey, width: number) => void;
+        reset: () => void;
+    };
+    stickyColumnsOffset: Readable<Map<ColumnKey, number>>;
+    lastStickyColumn: Readable<ColumnKey | undefined>;
+    isHorizontallyScrolled: Writable<boolean>;
 };


### PR DESCRIPTION
## Summary

The goal for this PR is to scope the sticky stores so that the state isn't shared between all the instances of the components. 

We didn't see it much, because stickyness is reset in most cases. But in cases like navigating between pages with tables, the "isScrolled" state could be preserved. We don't have yet any place where multiple table with sticky columns, but this would have crashed as well.

### Changes
Made a factory and istanciate the store in the root component and then pass it around with a context to avoid props drilling and benifit from derived state.

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [x] Tests coverage has improved
- [x] Code is ready for a release on NPM
