### PR TITLE
fix(api-client): Typo in attachment property name

### DIFF
--- a/packages/api-client/src/client/types.ts
+++ b/packages/api-client/src/client/types.ts
@@ -63,7 +63,7 @@ export type Dataset = DataWithLinks & {
     metas: object;
     fields: DatasetField[];
     visibility: 'restricted' | 'domain';
-    attachements: DatasetAttachement[];
+    attachments: DatasetAttachement[];
     alternative_exports: DatasetAlternativeExport[];
 };
 

--- a/packages/api-client/src/client/types.ts
+++ b/packages/api-client/src/client/types.ts
@@ -34,14 +34,14 @@ export type DatasetFieldType = ValueOf<typeof ODS_DATASET_FIELD_TYPE>;
 
 export type DatasetFieldSemanticType = ValueOf<typeof ODS_DATASET_FIELD_SEMANTIC_TYPE>;
 
-export interface DatasetAttachement {
+export interface DatasetAttachment {
     id: string;
     mimetype: string;
     title: string;
     url: string;
 }
 
-export interface DatasetAlternativeExport extends DatasetAttachement {
+export interface DatasetAlternativeExport extends DatasetAttachment {
     description: string;
 }
 
@@ -63,7 +63,7 @@ export type Dataset = DataWithLinks & {
     metas: object;
     fields: DatasetField[];
     visibility: 'restricted' | 'domain';
-    attachments: DatasetAttachement[];
+    attachments: DatasetAttachment[];
     alternative_exports: DatasetAlternativeExport[];
 };
 


### PR DESCRIPTION
## Summary

The goal for this PR is to fix a sleeping typo in our `Dataset` type.

### Changes
See https://public.opendatasoft.com/api/explore/v2.1/catalog/datasets/weatherref-france-vigilance-meteo-departement/
The correct term is `attachment`, not `attachement`.

I also renamed types that also used this term. 

#### Breaking Changes

I suppose worst case it will break broken things 🙈 

### Changelog
The property names and types related to "Attachements" are renamed to "Attachment" to match the API syntax and terms.

## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
