### PR TITLE
fix: add an empty column in loading cells too

### DIFF
--- a/packages/visualizations-react/stories/Table/Table.stories.tsx
+++ b/packages/visualizations-react/stories/Table/Table.stories.tsx
@@ -121,7 +121,12 @@ Unstyled.args = {
 export const Loading = Template.bind({});
 Loading.args = {
     data: fetchingData,
-    options,
+    options: {
+        ...options,
+        rowProps: {
+            onClick: () => {}, // Just to have column that shouldn't have the loading indicator
+        },
+    },
 };
 
 export const emptyState = Template.bind({});

--- a/packages/visualizations/src/components/Table/Body.svelte
+++ b/packages/visualizations/src/components/Table/Body.svelte
@@ -24,6 +24,9 @@
     {#if loadingRowsNumber}
         {#each Array(loadingRowsNumber) as _}
             <tr>
+                {#if rowProps?.onClick}
+                    <td class="button-cell__empty" />
+                {/if}
                 {#each columns as __}
                     <LoadingCell />
                 {/each}
@@ -45,4 +48,7 @@
 </tbody>
 
 <style>
+    .button-cell__empty {
+        min-width: 28px;
+    }
 </style>


### PR DESCRIPTION
## Summary

The goal for this PR is to fix a case where loading cell would be misaligned with actual columns when a button column was present.

The cause is that we insert an extra column if `rowProps.onclick` is defined, but didin't do it on the loading part.

### Changes
Add an empty cell with a min-width of 28px (button width) so that column count and alignment is preserved.

I added it to the loading story too to have a snapshot.

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [x] 2 reviewers (1 if trivial)
- [x] Tests coverage has improved
- [x] Code is ready for a release on NPM
