### PR TITLE
[API-CLIENT][FEAT] Add metadata template field type and ODSQL lower function

### DIFF
--- a/packages/api-client/src/client/constants.ts
+++ b/packages/api-client/src/client/constants.ts
@@ -17,6 +17,26 @@ export const ODS_DATASET_FIELD_SEMANTIC_TYPE = {
     MONITORING_IP_ADDRESS: 'monitoring_ip_address',
 } as const;
 
+export const ODS_METADATA_TEMPLATE_FIELD_TYPE = {
+    TEXT: 'text',
+    ENUM: 'enum',
+    ENUM_LIST: 'enumlist',
+    URI_ENUM: 'uri_enum',
+    URI_ENUM_LIST: 'uri_enumlist',
+    LIST: 'list',
+    DATE: 'date',
+    DATE_TIME: 'datetime',
+    BOOLEAN: 'boolean',
+    INTEGER: 'int',
+    DECIMAL: 'double',
+    HTML: 'html',
+    LONG_STRING: 'longstring',
+    /** It stores a value that references a polygon, a linear ring, multiple polygons, multiple lines, or multiple points */
+    GEO_SHAPE: 'geo_shape',
+    JSON: 'json',
+    IMAGE: 'image',
+};
+
 export const EXPORT_DATASET_FORMAT = {
     JSON: 'json',
     GEOJSON: 'geojson',

--- a/packages/api-client/src/client/types.ts
+++ b/packages/api-client/src/client/types.ts
@@ -6,6 +6,7 @@ import {
     EXPORT_DATASET_FORMAT,
     ODS_DATASET_FIELD_TYPE,
     ODS_DATASET_FIELD_SEMANTIC_TYPE,
+    ODS_METADATA_TEMPLATE_FIELD_TYPE,
 } from './constants';
 
 export interface Facet {
@@ -33,6 +34,8 @@ interface DataWithLinks {
 export type DatasetFieldType = ValueOf<typeof ODS_DATASET_FIELD_TYPE>;
 
 export type DatasetFieldSemanticType = ValueOf<typeof ODS_DATASET_FIELD_SEMANTIC_TYPE>;
+
+export type MetadataTemplateFieldType = ValueOf<typeof ODS_METADATA_TEMPLATE_FIELD_TYPE>;
 
 export interface DatasetAttachment {
     id: string;

--- a/packages/api-client/src/odsql/index.ts
+++ b/packages/api-client/src/odsql/index.ts
@@ -168,6 +168,17 @@ export const string = (value: string) => JSON.stringify(value);
 
 export const dateTime = (date: Date) => `date'${date.toISOString()}'`;
 
+/**
+ * ODSQL function to normalize field name.
+ *
+ * - Can be used for `order_by` and `group_by` clauses.
+ * - Example usage: `select=count(*) & group_by=lower(artist)`.
+ *
+ * @param {string} fieldName - The field name to normalize.
+ * @returns {string}  The lower ODSQL function.
+ */
+export const lower = (fieldName: string) => `lower(${fieldName})`;
+
 function inlineMonthOrDay(value?: number) {
     if (value === undefined) return '';
     if (value < 10) return `-0${value}`;

--- a/packages/api-client/test/odsql.test.ts
+++ b/packages/api-client/test/odsql.test.ts
@@ -20,6 +20,7 @@ import {
     textSearch,
     textSuggest,
     textStartWith,
+    lower,
 } from '../src';
 
 describe('ODSQL query builder', () => {
@@ -95,6 +96,10 @@ describe('ODSQL query builder', () => {
                     .where((prev) => all(prev, searchTerm && `search(${string(searchTerm)})`))
                     .toString()
             ).toEqual('catalog/assets/?where=%28search%28%22my+search+term%22%29%29');
+        });
+
+        test('text helpers', () => {
+            expect(lower('artist')).toEqual('lower(artist)');
         });
 
         test('list helper', () => {


### PR DESCRIPTION
## Summary

The goal for this PR is to add utils to the api client package

(Internal for Opendatasoft only) Associated Shortcut ticket: 🏴‍☠️ 

### Changes

- Package has type and constant for metadata template field types
- Add a new ODSQL function lower

## Open discussion

About the lower function.
I think we'll mostly use the combination `lower(field(' my field'))` when building queries
  
Do you see any reasons to not run the `field()` function inside `lower()` ?

We can't call `lower` inside `field` because it is not supported in every clause.
  
Other possibility would be to have optional arguments when calling `orderBy` or  `groupBy` to include the lower function but that requires to rewrite mostly all the logic of the Query class.
