### PR TITLE
[FEAT][CHART] add TimeDisplayFormats for chart options

### DIFF
--- a/packages/visualizations-react/stories/Chart/TimeScale/ChartTimeScale.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/TimeScale/ChartTimeScale.stories.tsx
@@ -133,6 +133,53 @@ const LineChartMonthsArgs: Props<DataFrame, ChartOptions> = {
 };
 LineChartMonths.args = LineChartMonthsArgs;
 
+export const LineChartWeeks = ChartTemplate.bind({});
+const LineChartWeeksArgs: Props<DataFrame, ChartOptions> = {
+    data: {
+        loading: false,
+        value: generateArrayOf(
+            index => {
+                const startDate = new Date('2025-01-06T00:00:00');
+                const newDate = new Date(startDate.getTime());
+                newDate.setDate(startDate.getDate() + (index * 7));
+                const year = newDate.getFullYear();
+                const month = (newDate.getMonth() + 1.).toString().padStart(2, '0');
+                const day = newDate.getDate().toString().padStart(2, '0');
+                return ({
+                    x: `${year}-${month}-${day}`,
+                    y: (index - 8) ** 2,
+                });
+            },
+            16,
+        ),
+    },
+    options: {
+        labelColumn: 'x',
+        series: [
+            {
+                type: ChartSeriesType.Line,
+                valueColumn: 'y',
+                borderColor: COLORS.blue,
+            },
+        ],
+        axis: {
+            x: {
+                display: true,
+                type: 'time',
+                timeUnit: 'week',
+                timeDisplayFormats: { week: "'W'WW yyyy" },
+            },
+            y: {
+                display: true,
+            },
+        },
+        title: {
+            text: 'Weeks',
+        },
+    },
+};
+LineChartWeeks.args = LineChartWeeksArgs;
+
 export const LineChartDays = ChartTemplate.bind({});
 const LineChartDaysArgs: Props<DataFrame, ChartOptions> = {
     data: {

--- a/packages/visualizations/src/components/Chart/scales.ts
+++ b/packages/visualizations/src/components/Chart/scales.ts
@@ -61,7 +61,7 @@ const DATE_TOOLTIP_FORMATS = {
     minute: DateTime.DATETIME_MED,
     hour: DateTime.DATETIME_MED,
     day: { day: 'numeric', month: 'long' },
-    week: 'DD',
+    week: "'W'WW yyyy",
     month: { month: 'long', year: 'numeric' },
     quarter: "'Q'q - yyyy",
     year: { year: 'numeric' },
@@ -93,6 +93,10 @@ export default function buildScales(options: ChartOptions): ChartJsChartOptions[
                       time: {
                           unit: options?.axis?.x?.timeUnit,
                           tooltipFormat: getDateTooltipFormat(options?.axis?.x?.timeUnit),
+                          isoWeekday: true,
+                          displayFormats: {
+                              ...(options?.axis?.x?.timeDisplayFormats || {}),
+                          },
                       },
                   }
                 : {}),

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -63,6 +63,18 @@ export interface BaseCartesianAxisConfiguration {
     ticks?: TicksConfiguration;
 }
 
+interface TimeDisplayFormats {
+    millisecond?: string;
+    second?: string;
+    minute?: string;
+    hour?: string;
+    day?: string;
+    week?: string;
+    month?: string;
+    quarter?: string;
+    year?: string;
+}
+
 export interface TimeCartesianAxisConfiguration extends BaseCartesianAxisConfiguration {
     type: 'time';
     timeUnit?:
@@ -75,6 +87,7 @@ export interface TimeCartesianAxisConfiguration extends BaseCartesianAxisConfigu
         | 'minute'
         | 'second'
         | 'millisecond';
+    timeDisplayFormats?: TimeDisplayFormats;
 }
 
 export interface CategoryCartesianAxisConfiguration extends BaseCartesianAxisConfiguration {


### PR DESCRIPTION
## Summary

The goal for this PR is to improve the `TimeCartesianAxisConfiguration` type to add `TimeDisplayFormats`.
By exposing `TimeDisplayFormats`, we allow the modification of the display format of the labels on the graph axis.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-55009](https://app.shortcut.com/opendatasoft/story/55009/as-a-user-i-want-to-display-my-data-results-by-weeks-time-scale).

### Changes

Improve the type `TimeCartesianAxisConfiguration`.

### Changelog

In the Chart component: It's now possible to update the display for the x axis when the type is "time".

## Review checklist

- [X] Description is complete
- [X] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [X] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
