### PR TITLE
fix(Chart): allow customizing tooltip date formats

### DIFF
--- a/packages/visualizations-react/stories/Chart/TimeScale/ChartTimeScale.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/TimeScale/ChartTimeScale.stories.tsx
@@ -134,6 +134,8 @@ const LineChartMonthsArgs: Props<DataFrame, ChartOptions> = {
 LineChartMonths.args = LineChartMonthsArgs;
 
 export const LineChartWeeks = ChartTemplate.bind({});
+// used for x axis and tooltip but may be different for each
+const timeDisplayFormats = { week: "'W'WW yyyy" };
 const LineChartWeeksArgs: Props<DataFrame, ChartOptions> = {
     data: {
         loading: false,
@@ -167,7 +169,7 @@ const LineChartWeeksArgs: Props<DataFrame, ChartOptions> = {
                 display: true,
                 type: 'time',
                 timeUnit: 'week',
-                timeDisplayFormats: { week: "'W'WW yyyy" },
+                timeDisplayFormats,
             },
             y: {
                 display: true,
@@ -176,6 +178,7 @@ const LineChartWeeksArgs: Props<DataFrame, ChartOptions> = {
         title: {
             text: 'Weeks',
         },
+        tooltip: { timeDisplayFormats }
     },
 };
 LineChartWeeks.args = LineChartWeeksArgs;

--- a/packages/visualizations/src/components/Chart/scales.ts
+++ b/packages/visualizations/src/components/Chart/scales.ts
@@ -15,6 +15,7 @@ import type {
     GridLinesConfiguration,
     TicksConfiguration,
     TimeCartesianAxisConfiguration,
+    TimeDisplayFormats,
 } from './types';
 import { defaultValue, singleChartJsColor } from './utils';
 
@@ -67,9 +68,14 @@ const DATE_TOOLTIP_FORMATS = {
     year: { year: 'numeric' },
 };
 
-function getDateTooltipFormat(unit?: TimeCartesianAxisConfiguration['timeUnit']) {
-    if (unit) return DATE_TOOLTIP_FORMATS[unit];
-    return undefined;
+function getDateTooltipFormat(
+    unit?: TimeCartesianAxisConfiguration['timeUnit'],
+    customFormats?: TimeDisplayFormats
+) {
+    if (customFormats && unit && customFormats[unit]) {
+        return customFormats[unit];
+    }
+    return unit ? DATE_TOOLTIP_FORMATS[unit] : undefined;
 }
 
 export default function buildScales(options: ChartOptions): ChartJsChartOptions['scales'] {
@@ -92,7 +98,10 @@ export default function buildScales(options: ChartOptions): ChartJsChartOptions[
                 ? {
                       time: {
                           unit: options?.axis?.x?.timeUnit,
-                          tooltipFormat: getDateTooltipFormat(options?.axis?.x?.timeUnit),
+                          tooltipFormat: getDateTooltipFormat(
+                              options?.axis?.x?.timeUnit,
+                              options?.tooltip?.timeDisplayFormats
+                          ),
                           isoWeekday: true,
                           displayFormats: {
                               ...(options?.axis?.x?.timeDisplayFormats || {}),

--- a/packages/visualizations/src/components/Chart/scales.ts
+++ b/packages/visualizations/src/components/Chart/scales.ts
@@ -72,10 +72,7 @@ function getDateTooltipFormat(
     unit?: TimeCartesianAxisConfiguration['timeUnit'],
     customFormats?: TimeDisplayFormats
 ) {
-    if (customFormats && unit && customFormats[unit]) {
-        return customFormats[unit];
-    }
-    return unit ? DATE_TOOLTIP_FORMATS[unit] : undefined;
+    return unit ? customFormats?.[unit] || DATE_TOOLTIP_FORMATS[unit] : undefined;
 }
 
 export default function buildScales(options: ChartOptions): ChartJsChartOptions['scales'] {

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -133,7 +133,7 @@ export interface TooltipConfiguration {
     rtl?: boolean;
     /** Custom number formatting function for tooltips values */
     numberFormatter?: (value: number) => string;
-    /** Custom time formats for tooltips values */
+    /** Custom time formats for each unit for tooltips values */
     timeDisplayFormats?: TimeDisplayFormats;
 }
 

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -63,7 +63,7 @@ export interface BaseCartesianAxisConfiguration {
     ticks?: TicksConfiguration;
 }
 
-interface TimeDisplayFormats {
+export interface TimeDisplayFormats {
     millisecond?: string;
     second?: string;
     minute?: string;
@@ -133,6 +133,8 @@ export interface TooltipConfiguration {
     rtl?: boolean;
     /** Custom number formatting function for tooltips values */
     numberFormatter?: (value: number) => string;
+    /** Custom time formats for tooltips values */
+    timeDisplayFormats?: TimeDisplayFormats;
 }
 
 export interface FontConfiguration {


### PR DESCRIPTION
## Summary

The goal for this PR is to control the date format displayed in Chart.js tooltips through a new property called `timeDisplayFormats`.

(Internal for Opendatasoft only) Associated Shortcut ticket: 🏴‍☠️

### Changes

- new optional property `timeDisplayFormats` to the `TooltipConfiguration` interface.
- `scales.ts` use `timeDisplayFormats` property and prioritize it when formatting tooltip dates
- Fix storybook sample

#### Breaking Changes

None

### Changelog

In the Chart component: It's now possible to customize date formats in tooltips using the `timeDisplayFormats` property.


## Open discussion

The implementation choice (`timeDisplayFormats`) is aligned with existing Chart.js conventions.
An alternative using functions (`dateFormatter`) was considered but postponed due to complexity in existing tooltip logic.

## To be tested

- Verify that custom date formats are correctly applied in tooltips
- backward compatibility: the default formats still apply when `timeDisplayFormats` is not provided

## Review checklist

- [X] Description is complete
- [X] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [X] 2 reviewers (1 if trivial)
- [X] Tests coverage has improved
- [X] Code is ready for a release on NPM
