### PR TITLE
[FEAT] Map -  support line layers

### DIFF
--- a/packages/visualizations-react/stories/Poi/PoiMap.stories.tsx
+++ b/packages/visualizations-react/stories/Poi/PoiMap.stories.tsx
@@ -63,7 +63,25 @@ const moselleLayer: Layer = {
     opacity: 0.3,
 };
 
-const layers = [citiesLayer, battlesLayer, moselleLayer];
+const maginotLayer: Layer = {
+    id: 'layer-maginot',
+    source: 'maginot',
+    type: 'line',
+    color: '#6E0F12',
+    width: 2,
+    opacity: 0.8,
+};
+
+const riversLayer = {
+    id: 'layer-rivers',
+    source: 'rivers',
+    type: 'line',
+    color: '#0000FF',
+    width: 1,
+    opacity: 0.5,
+};
+
+const layers = [citiesLayer, battlesLayer, moselleLayer, maginotLayer, riversLayer];
 
 const citiesColorMatch = {
     key: 'key',
@@ -139,10 +157,31 @@ const legendMoselleItems: CategoryItem[] = [
     },
 ];
 
+const legendMaginotItems: CategoryItem[] = [
+    {
+        variant: CATEGORY_ITEM_VARIANT.Line,
+        label: 'Maginot Line',
+        borderColor: maginotLayer.color,
+    },
+];
+
+const legendRiversItems: CategoryItem[] = [
+    {
+        variant: CATEGORY_ITEM_VARIANT.Line,
+        label: 'French rivers',
+        borderColor: riversLayer.color,
+    },
+];
 const legend = {
     type: 'category' as const,
-    title: 'French cities and famous battles',
-    items: [...legendCitiesItems, ...legendbattleItems, ...legendMoselleItems],
+    title: 'Legend',
+    items: [
+        ...legendCitiesItems,
+        ...legendbattleItems,
+        ...legendMoselleItems,
+        ...legendMaginotItems,
+        ...legendRiversItems,
+    ],
     align: 'start' as const,
 };
 
@@ -236,6 +275,8 @@ const PoiMapLegendStartArgs = {
                 { ...citiesLayer, colorMatch: citiesColorMatch },
                 { ...battlesLayer, iconImageMatch: battleImageMatch },
                 moselleLayer,
+                maginotLayer,
+                riversLayer,
             ],
             sources,
         },
@@ -255,6 +296,8 @@ const PoiMapLegendCenterArgs = {
                 { ...citiesLayer, colorMatch: citiesColorMatch },
                 { ...battlesLayer, iconImageMatch: battleImageMatch },
                 moselleLayer,
+                maginotLayer,
+                riversLayer,
             ],
             sources,
         },
@@ -274,6 +317,8 @@ const PoiMapMinMaxZoomsArgs = {
                 { ...citiesLayer, colorMatch: citiesColorMatch },
                 { ...battlesLayer, iconImageMatch: battleImageMatch },
                 moselleLayer,
+                maginotLayer,
+                riversLayer,
             ],
             sources,
         },
@@ -298,6 +343,8 @@ const PoiMapCooperativeGesturesArgs = {
                 { ...citiesLayer, colorMatch: citiesColorMatch },
                 { ...battlesLayer, iconImageMatch: battleImageMatch },
                 moselleLayer,
+                maginotLayer,
+                riversLayer,
             ],
             sources,
         },

--- a/packages/visualizations-react/stories/Poi/sources.ts
+++ b/packages/visualizations-react/stories/Poi/sources.ts
@@ -108,6 +108,52 @@ const sources : Required<PoiMapData>["value"]["sources"] = {
     moselle: {
         type: 'geojson',
         data: 'https://france-geojson.gregoiredavid.fr/repo/departements/57-moselle/departement-57-moselle.geojson'
+    },
+    maginot: {
+        type: "geojson",
+        data: {
+            "type": "Feature",
+            "properties": {
+              "name": "Ligne Maginot",
+              "description": "Simplified path of the Maginot Line along the French eastern border."
+            },
+            "geometry": {
+              "type": "LineString",
+              "coordinates": [
+                [7.5536, 47.5649],
+                [7.3328, 47.7480],
+                [7.2561, 48.0000],
+                [7.3000, 48.2500],
+                [7.2000, 48.6000],
+                [7.1000, 48.9000],
+                [6.9500, 49.2000],
+                [6.7000, 49.5000],
+                [6.4000, 49.6000],
+                [5.9500, 49.5500]
+              ]
+            }
+        }
+    },
+    rivers: {
+        type: 'geojson',
+        data: {
+            "type": "Feature",
+            "properties": {
+              "name": "Fleuves Français",
+              "description": "Principaux fleuves de France sous forme de MultiLineString"
+            },
+            "geometry": {
+              "type": "MultiLineString",
+              "coordinates": [
+                [[-0.5669, 47.25], [0.0833, 47.35], [0.68, 47.39],[1.25, 47.39], [2.0, 47.2], [3.1, 47.4], [4.8, 47.0]],
+                [[0.15, 49.5], [0.5, 49.4], [1.2, 49.0], [2.35, 48.85],[3.3, 48.5], [3.5, 48.0]],
+                [[6.1, 46.2], [5.7, 45.9], [4.83, 45.76], [4.7, 44.5],[4.9, 43.8]],
+                [[0.55, 42.8], [0.75, 43.5], [1.44, 43.6], [1.8, 44.0],[-0.57, 44.8]],
+                [[7.55, 47.56], [7.6, 48.0], [7.7, 48.5], [7.7, 49.0]],
+                [[7.0, 44.1], [7.1, 43.9], [7.2, 43.8]]
+              ]
+            }
+        }
     }
 };
 

--- a/packages/visualizations/src/components/Map/WebGl/types.ts
+++ b/packages/visualizations/src/components/Map/WebGl/types.ts
@@ -9,6 +9,7 @@ import type {
     StyleImageMetadata,
     StyleSpecification,
     SymbolLayerSpecification,
+    LineLayerSpecification,
 } from 'maplibre-gl';
 import type { BBox, GeoJsonProperties } from 'geojson';
 import type { Color } from 'types';
@@ -68,7 +69,8 @@ export type WebGlMapStyleOption = Partial<Pick<StyleSpecification, 'sources' | '
 export type LayerSpecification =
     | CircleLayerSpecification
     | SymbolLayerSpecification
-    | FillLayerSpecification;
+    | FillLayerSpecification
+    | LineLayerSpecification;
 
 type BaseLayer = {
     id: string;
@@ -122,7 +124,14 @@ export type FillLayer = BaseLayer & {
     opacity?: number;
 };
 
-export type Layer = CircleLayer | SymbolLayer | FillLayer;
+export type LineLayer = BaseLayer & {
+    type: LineLayerSpecification['type'];
+    color: Color;
+    width?: number;
+    opacity?: number;
+};
+
+export type Layer = CircleLayer | SymbolLayer | FillLayer | LineLayer;
 
 export type GeoPoint = {
     lat: number;

--- a/packages/visualizations/src/components/Map/WebGl/utils.ts
+++ b/packages/visualizations/src/components/Map/WebGl/utils.ts
@@ -6,6 +6,7 @@ import type {
     ExpressionInputType,
     SymbolLayerSpecification,
     FillLayerSpecification,
+    LineLayerSpecification,
 } from 'maplibre-gl';
 
 import { isGroupByForMatchExpression, Color } from 'types';
@@ -20,6 +21,7 @@ import type {
     SymbolLayer,
     CenterZoomOptions,
     FillLayer,
+    LineLayer,
 } from './types';
 import { DEFAULT_DARK_GREY, DEFAULT_BASEMAP_STYLE, DEFAULT_SORT_KEY_VALUE } from './constants';
 
@@ -142,6 +144,21 @@ const getMapFillLayer = (layer: FillLayer): FillLayerSpecification => {
         },
     };
 };
+
+const getMapLineLayer = (layer: LineLayer): LineLayerSpecification => {
+    const { type, color, width, opacity } = layer;
+
+    return {
+        ...getBaseMapLayerConfiguration(layer),
+        filter: ['==', ['geometry-type'], 'LineString'],
+        type,
+        paint: {
+            'line-color': color,
+            ...(width && { 'line-width': width }),
+            ...(opacity && { 'line-opacity': opacity }),
+        },
+    };
+};
 // Circle, symbol and fill layers are supported
 export const getMapLayers = (layers?: Layer[]): LayerSpecification[] => {
     if (!layers) return [];
@@ -153,8 +170,10 @@ export const getMapLayers = (layers?: Layer[]): LayerSpecification[] => {
                 return getMapSymbolLayer(layer);
             case 'fill':
                 return getMapFillLayer(layer);
+            case 'line':
+                return getMapLineLayer(layer);
             default:
-                throw new Error(`Unexepected layer type for layer: ${layer}`);
+                throw new Error(`Unexpected layer type for layer: ${layer}`);
         }
     });
 };


### PR DESCRIPTION
## Summary

The goal for this PR is to draw lines layers on Webgl Maplibre maps

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-55946](https://app.shortcut.com/opendatasoft/story/55946).

### Changes

- Update layers util to build line layers from props
- Update stories 

