### PR TITLE
feat(api-client): Support timezone parameter

### DIFF
--- a/packages/api-client/src/odsql/index.ts
+++ b/packages/api-client/src/odsql/index.ts
@@ -130,6 +130,10 @@ export class Query {
     lang(lang: string): Query {
         return this.set('lang', lang);
     }
+
+    timezone(timezone: string): Query {
+        return this.set('timezone', timezone);
+    }
 }
 
 function root(source: string) {

--- a/packages/api-client/test/odsql.test.ts
+++ b/packages/api-client/test/odsql.test.ts
@@ -173,9 +173,10 @@ describe('ODSQL query builder', () => {
                     )
                     .select('a')
                     .select((selected) => `${selected}, b`)
+                    .timezone('Europe/Paris')
                     .toString()
             ).toEqual(
-                'catalog/datasets/my_dataset/records/?group_by=x%2C+y&select=a%2C+b&where=%28%28%60my_field%60%3A%22this+will+be%27+escaped%22%29+OR+%28%60my_field%60+%3C+date%271970-01-01%27%29%29+AND+%28not_escaped+in+%5B0..10%5D+and+other+is+true%29+AND+%28len%28f%29+%3D+2%29'
+                'catalog/datasets/my_dataset/records/?group_by=x%2C+y&select=a%2C+b&timezone=Europe%2FParis&where=%28%28%60my_field%60%3A%22this+will+be%27+escaped%22%29+OR+%28%60my_field%60+%3C+date%271970-01-01%27%29%29+AND+%28not_escaped+in+%5B0..10%5D+and+other+is+true%29+AND+%28len%28f%29+%3D+2%29'
             );
 
             expect(


### PR DESCRIPTION
## Summary

The goal for this PR is to add support to the `timezone` parameter.

### Changes

Just add a `.timezone(<timezone>)` parameter, similar to the others like `lang` etc.

#### Breaking Changes

None

### Changelog

We added a new `timezone()` function on queries, to support the `timezone` parameter in API endpoints.

## Review checklist

- [x] Description is complete
- [x] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [x] Tests coverage has improved
- [x] Code is ready for a release on NPM
