### PR TITLE
[API-CLIENT][FIX] add type: `MetadataTemplateType`

### DIFF
--- a/packages/api-client/src/client/constants.ts
+++ b/packages/api-client/src/client/constants.ts
@@ -17,6 +17,13 @@ export const ODS_DATASET_FIELD_SEMANTIC_TYPE = {
     MONITORING_IP_ADDRESS: 'monitoring_ip_address',
 } as const;
 
+export const ODS_METADATA_TEMPLATE_TYPE = {
+    ADMIN: 'admin',
+    BASIC: 'basic',
+    INTEROP: 'interop',
+    EXTRA: 'extra',
+} as const;
+
 export const ODS_METADATA_TEMPLATE_FIELD_TYPE = {
     TEXT: 'text',
     ENUM: 'enum',
@@ -35,7 +42,7 @@ export const ODS_METADATA_TEMPLATE_FIELD_TYPE = {
     GEO_SHAPE: 'geo_shape',
     JSON: 'json',
     IMAGE: 'image',
-};
+} as const;
 
 export const EXPORT_DATASET_FORMAT = {
     JSON: 'json',

--- a/packages/api-client/src/client/types.ts
+++ b/packages/api-client/src/client/types.ts
@@ -7,6 +7,7 @@ import {
     ODS_DATASET_FIELD_TYPE,
     ODS_DATASET_FIELD_SEMANTIC_TYPE,
     ODS_METADATA_TEMPLATE_FIELD_TYPE,
+    ODS_METADATA_TEMPLATE_TYPE,
 } from './constants';
 
 export interface Facet {
@@ -34,6 +35,8 @@ interface DataWithLinks {
 export type DatasetFieldType = ValueOf<typeof ODS_DATASET_FIELD_TYPE>;
 
 export type DatasetFieldSemanticType = ValueOf<typeof ODS_DATASET_FIELD_SEMANTIC_TYPE>;
+
+export type MetadataTemplateType = ValueOf<typeof ODS_METADATA_TEMPLATE_TYPE>;
 
 export type MetadataTemplateFieldType = ValueOf<typeof ODS_METADATA_TEMPLATE_FIELD_TYPE>;
 


### PR DESCRIPTION
## Summary

The goal for this PR is to add a new type MetadataTemplateType and fix a const declaration for `ODS_METADATA_TEMPLATE_FIELD_TYPE`

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-58684](https://app.shortcut.com/opendatasoft/story/58684).