### PR TITLE
fix(Table): Missing labels for accessibility

### DIFF
--- a/packages/visualizations/src/components/Pagination/PageSize.svelte
+++ b/packages/visualizations/src/components/Pagination/PageSize.svelte
@@ -5,6 +5,7 @@
     export let options: PageSizeOption[];
     export let onChange: (size: number) => void;
     export let selected: number;
+    export let selectLabel = 'Number of records per page';
 
     let value: number;
 
@@ -17,7 +18,11 @@
     }
 </script>
 
-<select bind:value on:input={(e) => onChange(toNumber(e.currentTarget.value))}>
+<select
+    bind:value
+    on:input={(e) => onChange(toNumber(e.currentTarget.value))}
+    aria-label={selectLabel}
+>
     {#each options as option}
         <option label={option.label} value={option.value} />
     {/each}

--- a/packages/visualizations/src/components/Pagination/Pagination.svelte
+++ b/packages/visualizations/src/components/Pagination/Pagination.svelte
@@ -33,7 +33,11 @@
         </div>
         <div class="page-size">
             {#if pageSizeSelect}
-                <PageSize selected={recordsPerPage} {...pageSizeSelect} />
+                <PageSize
+                    selected={recordsPerPage}
+                    {...pageSizeSelect}
+                    selectLabel={labels?.pageSizeSelect}
+                />
             {/if}
         </div>
     </div>

--- a/packages/visualizations/src/components/Pagination/Pagination.svelte
+++ b/packages/visualizations/src/components/Pagination/Pagination.svelte
@@ -36,7 +36,7 @@
                 <PageSize
                     selected={recordsPerPage}
                     {...pageSizeSelect}
-                    selectLabel={labels?.pageSizeSelect}
+                    selectLabel={labels?.pageSizeAriaLabel}
                 />
             {/if}
         </div>

--- a/packages/visualizations/src/components/Pagination/types.ts
+++ b/packages/visualizations/src/components/Pagination/types.ts
@@ -19,5 +19,6 @@ export type Pagination = {
         firstPage: string;
         lastPage: string;
         records: string;
+        pageSizeSelect: string;
     }>;
 };

--- a/packages/visualizations/src/components/Pagination/types.ts
+++ b/packages/visualizations/src/components/Pagination/types.ts
@@ -19,6 +19,6 @@ export type Pagination = {
         firstPage: string;
         lastPage: string;
         records: string;
-        pageSizeSelect: string;
+        pageSizeAriaLabel: string;
     }>;
 };

--- a/packages/visualizations/src/components/Table/Headers/Headers.svelte
+++ b/packages/visualizations/src/components/Table/Headers/Headers.svelte
@@ -4,12 +4,13 @@
 
     export let columns: Column[];
     export let extraButtonColumn = false;
+    export let extraButtonColumnLabel: string | undefined;
 </script>
 
 <thead>
     <tr>
         {#if extraButtonColumn}
-            <Th />
+            <Th {extraButtonColumnLabel} />
         {/if}
         {#each columns as column (column.key)}
             <Th {column} />

--- a/packages/visualizations/src/components/Table/Headers/Th.svelte
+++ b/packages/visualizations/src/components/Table/Headers/Th.svelte
@@ -6,6 +6,7 @@
     import SortButton from './SortButton.svelte';
 
     export let column: Column | null = null;
+    export let extraButtonColumnLabel = 'Action';
 
     const { stickyColumnsWidth, stickyColumnsOffset, isHorizontallyScrolled, lastStickyColumn } =
         getContext<StickyStores>('sticky-stores');
@@ -57,6 +58,7 @@
             scrolled: $isHorizontallyScrolled,
             lastStickyColumn: $lastStickyColumn,
         })}`}
+        aria-label={extraButtonColumnLabel}
     />
 {/if}
 

--- a/packages/visualizations/src/components/Table/Table.svelte
+++ b/packages/visualizations/src/components/Table/Table.svelte
@@ -14,6 +14,7 @@
     export let description: string | undefined;
     export let emptyStateLabel: string | undefined;
     export let rowProps: RowProps | undefined;
+    export let extraButtonColumnLabel: string | undefined;
 
     const tableId = `table-${generateId()}`;
 
@@ -57,7 +58,11 @@
 
 <div class="scrollbox" bind:this={scrollBox} on:scroll={handleScroll}>
     <table aria-describedby={description ? tableId : undefined}>
-        <Headers columns={sortedStickyColumns} extraButtonColumn={Boolean(rowProps?.onClick)} />
+        <Headers
+            columns={sortedStickyColumns}
+            extraButtonColumn={Boolean(rowProps?.onClick)}
+            {extraButtonColumnLabel}
+        />
         <Body
             {records}
             columns={sortedStickyColumns}

--- a/packages/visualizations/src/components/Table/TableCard.svelte
+++ b/packages/visualizations/src/components/Table/TableCard.svelte
@@ -24,6 +24,7 @@
         locale: localeOption,
         pagination,
         emptyStateLabel,
+        extraButtonColumnLabel,
         debugWarnings: debugOption = false,
     } = options);
     $: $locale = localeOption || navigator.language;
@@ -37,7 +38,15 @@
 
 <Card {title} {subtitle} {links} defaultStyle={!unstyled}>
     <div class="table-container">
-        <Table {columns} {loadingRowsNumber} {records} {description} {emptyStateLabel} {rowProps} />
+        <Table
+            {columns}
+            {loadingRowsNumber}
+            {records}
+            {description}
+            {emptyStateLabel}
+            {extraButtonColumnLabel}
+            {rowProps}
+        />
         {#if pagination}
             <Pagination {...pagination} />
         {/if}

--- a/packages/visualizations/src/components/Table/types.ts
+++ b/packages/visualizations/src/components/Table/types.ts
@@ -95,6 +95,7 @@ export type TableOptions = {
     subtitle?: string;
     description?: string;
     emptyStateLabel?: string;
+    extraButtonColumnLabel?: string;
     links?: Link[];
     /** To format date and number with the right locale. Default is from browser language */
     locale?: string;


### PR DESCRIPTION
## Summary

The goal for this PR is to add two missing labels, invisible in the page, but useful for screen readers and other accessibility user agents.

(Internal for Opendatasoft only) Associated Shortcut ticket: 
- [sc-60636](https://app.shortcut.com/huwise/story/60636)
- [sc-60637](https://app.shortcut.com/huwise/story/60637)

### Changes
- Added a label to the `th` that is added for the "extra button column" (used for "Open record" in the platform)
- Added a label to the `select` used to select the number of records per page in the pagination control
- Exposed the labels as properties so that we can inject translated terms from the platform


## To be tested
This can be tested in Storybook, using the browser inspector


## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
