### PR TITLE
feat: support action items and href onClick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23155,7 +23155,7 @@
         },
         "packages/visualizations": {
             "name": "@opendatasoft/visualizations",
-            "version": "0.32.1-beta.0",
+            "version": "0.32.1-beta.1",
             "license": "MIT",
             "dependencies": {
                 "@placemarkio/geo-viewport": "^1.0.2",
@@ -23231,10 +23231,10 @@
         },
         "packages/visualizations-react": {
             "name": "@opendatasoft/visualizations-react",
-            "version": "0.32.1-beta.0",
+            "version": "0.32.1-beta.1",
             "license": "MIT",
             "dependencies": {
-                "@opendatasoft/visualizations": "0.32.1-beta.0",
+                "@opendatasoft/visualizations": "0.32.1-beta.1",
                 "use-callback-ref": "^1.2.4"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23155,7 +23155,7 @@
         },
         "packages/visualizations": {
             "name": "@opendatasoft/visualizations",
-            "version": "0.32.0",
+            "version": "0.32.1-beta.0",
             "license": "MIT",
             "dependencies": {
                 "@placemarkio/geo-viewport": "^1.0.2",
@@ -23231,10 +23231,10 @@
         },
         "packages/visualizations-react": {
             "name": "@opendatasoft/visualizations-react",
-            "version": "0.32.0",
+            "version": "0.32.1-beta.0",
             "license": "MIT",
             "dependencies": {
-                "@opendatasoft/visualizations": "0.32.0",
+                "@opendatasoft/visualizations": "0.32.1-beta.0",
                 "use-callback-ref": "^1.2.4"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23155,7 +23155,7 @@
         },
         "packages/visualizations": {
             "name": "@opendatasoft/visualizations",
-            "version": "0.33.0-beta.0",
+            "version": "0.33.0",
             "license": "MIT",
             "dependencies": {
                 "@placemarkio/geo-viewport": "^1.0.2",
@@ -23231,10 +23231,10 @@
         },
         "packages/visualizations-react": {
             "name": "@opendatasoft/visualizations-react",
-            "version": "0.33.0-beta.0",
+            "version": "0.33.0",
             "license": "MIT",
             "dependencies": {
-                "@opendatasoft/visualizations": "0.33.0-beta.0",
+                "@opendatasoft/visualizations": "0.33.0",
                 "use-callback-ref": "^1.2.4"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23155,7 +23155,7 @@
         },
         "packages/visualizations": {
             "name": "@opendatasoft/visualizations",
-            "version": "0.32.1",
+            "version": "0.33.0-beta.0",
             "license": "MIT",
             "dependencies": {
                 "@placemarkio/geo-viewport": "^1.0.2",
@@ -23231,10 +23231,10 @@
         },
         "packages/visualizations-react": {
             "name": "@opendatasoft/visualizations-react",
-            "version": "0.32.1",
+            "version": "0.33.0-beta.0",
             "license": "MIT",
             "dependencies": {
-                "@opendatasoft/visualizations": "0.32.1",
+                "@opendatasoft/visualizations": "0.33.0-beta.0",
                 "use-callback-ref": "^1.2.4"
             },
             "devDependencies": {

--- a/packages/visualizations-react/CHANGELOG.md
+++ b/packages/visualizations-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.32.1-beta.1](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations-react@0.32.1-beta.0...@opendatasoft/visualizations-react@0.32.1-beta.1) (2026-04-17)
+
+**Note:** Version bump only for package @opendatasoft/visualizations-react
+
+
+
+
+
 ## [0.32.1-beta.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations-react@0.32.0...@opendatasoft/visualizations-react@0.32.1-beta.0) (2026-04-16)
 
 

--- a/packages/visualizations-react/CHANGELOG.md
+++ b/packages/visualizations-react/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.32.1-beta.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations-react@0.32.0...@opendatasoft/visualizations-react@0.32.1-beta.0) (2026-04-16)
+
+
+### Features
+
+* support action items and href onClick ([d794795](https://github.com/opendatasoft/ods-dataviz-sdk/commit/d79479599d892d005be8245f1f47a57e59fea8c2))
+
+
+
+
+
 # [0.32.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations-react@0.30.0...@opendatasoft/visualizations-react@0.32.0) (2026-04-08)
 
 

--- a/packages/visualizations-react/CHANGELOG.md
+++ b/packages/visualizations-react/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.33.0-beta.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations-react@0.32.1...@opendatasoft/visualizations-react@0.33.0-beta.0) (2026-05-26)
+
+
+### Features
+
+* **LinksMenu:** add optional download attribute on LinkHref ([16ad99d](https://github.com/opendatasoft/ods-dataviz-sdk/commit/16ad99da608cc3c6411d2c082ef76f81cc00148c))
+* support action items and href onClick ([d794795](https://github.com/opendatasoft/ods-dataviz-sdk/commit/d79479599d892d005be8245f1f47a57e59fea8c2))
+
+
+
+
+
 ## [0.32.1](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations-react@0.32.0...@opendatasoft/visualizations-react@0.32.1) (2026-05-25)
 
 **Note:** Version bump only for package @opendatasoft/visualizations-react

--- a/packages/visualizations-react/CHANGELOG.md
+++ b/packages/visualizations-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.33.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations-react@0.33.0-beta.0...@opendatasoft/visualizations-react@0.33.0) (2026-06-16)
+
+**Note:** Version bump only for package @opendatasoft/visualizations-react
+
+
+
+
+
 # [0.33.0-beta.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations-react@0.32.1...@opendatasoft/visualizations-react@0.33.0-beta.0) (2026-05-26)
 
 

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations-react",
-    "version": "0.32.1-beta.0",
+    "version": "0.32.1-beta.1",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",
@@ -61,7 +61,7 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
-        "@opendatasoft/visualizations": "0.32.1-beta.0",
+        "@opendatasoft/visualizations": "0.32.1-beta.1",
         "use-callback-ref": "^1.2.4"
     },
     "devDependencies": {

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations-react",
-    "version": "0.32.0",
+    "version": "0.32.1-beta.0",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",
@@ -61,7 +61,7 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
-        "@opendatasoft/visualizations": "0.32.0",
+        "@opendatasoft/visualizations": "0.32.1-beta.0",
         "use-callback-ref": "^1.2.4"
     },
     "devDependencies": {

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations-react",
-    "version": "0.32.1",
+    "version": "0.33.0-beta.0",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",
@@ -61,7 +61,7 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
-        "@opendatasoft/visualizations": "0.32.1",
+        "@opendatasoft/visualizations": "0.33.0-beta.0",
         "use-callback-ref": "^1.2.4"
     },
     "devDependencies": {

--- a/packages/visualizations-react/package.json
+++ b/packages/visualizations-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations-react",
-    "version": "0.33.0-beta.0",
+    "version": "0.33.0",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",
@@ -61,7 +61,7 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
-        "@opendatasoft/visualizations": "0.33.0-beta.0",
+        "@opendatasoft/visualizations": "0.33.0",
         "use-callback-ref": "^1.2.4"
     },
     "devDependencies": {

--- a/packages/visualizations-react/src/index.ts
+++ b/packages/visualizations-react/src/index.ts
@@ -34,7 +34,11 @@ import type {
     URLFormatProps,
     NumberFormatProps,
     Link,
+    LinkHref,
+    LinkAction,
     LinksMenuProps,
+    LINKS_MENU_CLASS,
+    isLinkHref,
 } from '@opendatasoft/visualizations';
 import reactifySvelte from 'reactify';
 
@@ -90,5 +94,6 @@ export const LinksMenu = reactifySvelte<LinksMenuProps>(
     false
 );
 
-// Export types
-export type { Link, LinksMenuProps };
+// Export types and link helpers
+export type { Link, LinkHref, LinkAction, LinksMenuProps };
+export { isLinkHref, LINKS_MENU_CLASS };

--- a/packages/visualizations-react/src/index.ts
+++ b/packages/visualizations-react/src/index.ts
@@ -17,6 +17,8 @@ import {
     URLFormat as _URLFormat,
     NumberFormat as _NumberFormat,
     LinksMenu as _LinksMenu,
+    isLinkHref,
+    LINKS_MENU_CLASS,
 } from '@opendatasoft/visualizations';
 import type {
     ChartProps,
@@ -37,8 +39,6 @@ import type {
     LinkHref,
     LinkAction,
     LinksMenuProps,
-    LINKS_MENU_CLASS,
-    isLinkHref,
 } from '@opendatasoft/visualizations';
 import reactifySvelte from 'reactify';
 

--- a/packages/visualizations-react/stories/LinksMenu/LinksMenu.stories.tsx
+++ b/packages/visualizations-react/stories/LinksMenu/LinksMenu.stories.tsx
@@ -1,0 +1,317 @@
+import React, { useState } from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { ChartSeriesType, LINKS_MENU_CLASS, type Link } from '@opendatasoft/visualizations';
+import { Chart } from 'src';
+import { COLORS } from '../utils';
+
+type ClickLogEntry = {
+    at: string;
+    kind: 'href-tracked' | 'action';
+    label: string;
+    href?: string;
+};
+
+/* eslint-disable react/prop-types */
+function LinksMenuDemo({ options, ...rest }: React.ComponentProps<typeof Chart>) {
+    const [hrefTrackedClicks, setHrefTrackedClicks] = useState(0);
+    const [actionClicks, setActionClicks] = useState(0);
+    const [log, setLog] = useState<ClickLogEntry[]>([]);
+
+    const addLog = (entry: Omit<ClickLogEntry, 'at'>) =>
+        setLog(prev => [
+            { ...entry, at: new Date().toISOString() },
+            ...prev,
+        ].slice(0, 10));
+
+    const CODE_LIBRARY_HREF = 'https://codelibrary.opendatasoft.com/';
+
+    const hrefPlainLabel = 'Open Code Library (href, no onClick callback)';
+    const hrefTrackedLabel = 'Open Code Library (href, onClick tracking)';
+    const actionLabel = 'Show message (action, window.alert)';
+
+    const links: Link[] = [
+        {
+            href: CODE_LIBRARY_HREF,
+            label: hrefPlainLabel,
+        },
+        {
+            href: CODE_LIBRARY_HREF,
+            label: hrefTrackedLabel,
+            onClick: () => {
+                setHrefTrackedClicks(c => c + 1);
+                addLog({ kind: 'href-tracked', label: hrefTrackedLabel, href: CODE_LIBRARY_HREF });
+            },
+        },
+        {
+            label: actionLabel,
+            onClick: () => {
+                setActionClicks(c => c + 1);
+                addLog({ kind: 'action', label: actionLabel });
+                // eslint-disable-next-line no-alert
+                window.alert('LinksMenu action clicked');
+            },
+        },
+    ];
+
+    const storyCss = `
+.linksMenuStoryOuter{
+  padding:8px 12px 16px;
+  width:100%;
+  box-sizing:border-box;
+  font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  color:#111;
+}
+.linksMenuStoryGrid{
+  display:grid;
+  gap:16px;
+  align-items:start;
+  width:100%;
+  max-width:980px;
+  margin:0 auto;
+  grid-template-columns:minmax(0, 1fr);
+}
+@media (min-width: 900px){
+  .linksMenuStoryGrid{
+    grid-template-columns:minmax(0, 1fr) minmax(260px, 320px);
+  }
+}
+`;
+
+    const chartColumn: React.CSSProperties = {
+        minWidth: 0,
+        width: '100%',
+    };
+
+    const chartHost: React.CSSProperties = {
+        display: 'flex',
+        justifyContent: 'center',
+        width: '100%',
+    };
+
+    const chartFrame: React.CSSProperties = {
+        width: '100%',
+        maxWidth: 480,
+    };
+
+    const docColumn: React.CSSProperties = {
+        width: '100%',
+        maxWidth: 320,
+    };
+
+    const panel: React.CSSProperties = {
+        border: '1px solid #e6e6e6',
+        borderRadius: 10,
+        background: '#fff',
+        boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
+        padding: 14,
+    };
+
+    const h2: React.CSSProperties = {
+        margin: 0,
+        fontSize: 14,
+        fontWeight: 700,
+        letterSpacing: 0.2,
+    };
+
+    const muted: React.CSSProperties = {
+        margin: '10px 0 0',
+        fontSize: 12,
+        lineHeight: 1.45,
+        color: '#444',
+    };
+
+    const list: React.CSSProperties = {
+        margin: '10px 0 0',
+        paddingLeft: 18,
+        fontSize: 12,
+        lineHeight: 1.55,
+        color: '#333',
+    };
+
+    const code: React.CSSProperties = {
+        fontFamily:
+            'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+        fontSize: 12,
+        background: '#f6f8fa',
+        border: '1px solid #eef0f3',
+        borderRadius: 8,
+        padding: '10px 10px',
+        overflow: 'auto',
+    };
+
+    const inlineCode: React.CSSProperties = {
+        fontFamily: code.fontFamily,
+        fontSize: 12,
+        lineHeight: 'inherit',
+        background: '#f6f8fa',
+        border: '1px solid #eef0f3',
+        borderRadius: 6,
+        padding: '0 4px',
+        display: 'inline-block',
+        transform: 'translateY(0.5px)',
+    };
+
+    const divider: React.CSSProperties = {
+        height: 1,
+        background: '#eee',
+        margin: '14px 0',
+    };
+
+    const statRow: React.CSSProperties = {
+        display: 'flex',
+        justifyContent: 'space-between',
+        gap: 12,
+        fontSize: 12,
+        marginTop: 8,
+    };
+
+    const logList: React.CSSProperties = {
+        margin: '10px 0 0',
+        padding: 0,
+        listStyle: 'none',
+    };
+
+    const logItem: React.CSSProperties = {
+        marginTop: 10,
+    };
+
+    const logPre: React.CSSProperties = {
+        margin: 0,
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+        ...code,
+    };
+
+    return (
+        <>
+            <style>{storyCss}</style>
+            <div className="linksMenuStoryOuter">
+                <div className="linksMenuStoryGrid">
+                    <div style={chartColumn}>
+                        <div style={chartHost}>
+                            <div style={chartFrame}>
+                                <Chart
+                                    {...rest}
+                                    options={{
+                                        ...options,
+                                        links,
+                                    }}
+                                />
+                            </div>
+                        </div>
+                    </div>
+
+                    <aside style={{ ...panel, ...docColumn }}>
+                        <h2 style={h2}>LinksMenu</h2>
+                        <p style={muted}>
+                            This story uses a <code style={inlineCode}>Chart</code> only as a host. The interesting part is{' '}
+                            <code style={inlineCode}>options.links</code>, which is rendered by the SDK{' '}
+                            <code style={inlineCode}>LinksMenu</code>.
+                        </p>
+
+                        <div style={divider} />
+
+                        <h2 style={h2}>What you can pass</h2>
+                        <ul style={list}>
+                            <li>
+                                Demo menu items, first <strong>href</strong> without{' '}
+                                <code style={inlineCode}>onClick</code>, second <strong>href</strong> with{' '}
+                                <code style={inlineCode}>onClick</code> tracking, third <strong>action</strong> with{' '}
+                                <code style={inlineCode}>window.alert</code>
+                            </li>
+                            <li>
+                                <strong>LinkHref</strong>, navigational item, opens <code style={inlineCode}>href</code>{' '}
+                                in a new tab, optional <code style={inlineCode}>onClick</code> runs before navigation
+                            </li>
+                            <li>
+                                <strong>LinkAction</strong>, in menu action, renders as a button,{' '}
+                                <code style={inlineCode}>onClick</code> is required
+                            </li>
+                            <li>
+                                Optional <code style={inlineCode}>icon</code> on both shapes, SVG string
+                            </li>
+                        </ul>
+
+                        <p style={muted}>
+                            Type guard, <code style={inlineCode}>isLinkHref(link)</code>, wrapper class,{' '}
+                            <code style={inlineCode}>{LINKS_MENU_CLASS}</code>
+                            , useful when cloning the DOM for image export.
+                        </p>
+
+                        <div style={divider} />
+
+                        <h2 style={h2}>Click debug</h2>
+                        <div style={statRow}>
+                            <span>Href tracked onClick</span>
+                            <strong>{hrefTrackedClicks}</strong>
+                        </div>
+                        <div style={statRow}>
+                            <span>Action onClick</span>
+                            <strong>{actionClicks}</strong>
+                        </div>
+
+                        <div style={{ marginTop: 12, fontSize: 12, fontWeight: 700 }}>
+                            Log, latest first, JSON per line
+                        </div>
+                        <ul style={logList}>
+                            {log.map(e => (
+                                <li key={`${e.at}-${e.kind}-${e.label}`} style={logItem}>
+                                    <pre style={logPre}>{JSON.stringify(e, null, 2)}</pre>
+                                </li>
+                            ))}
+                        </ul>
+                    </aside>
+                </div>
+            </div>
+        </>
+    );
+}
+
+const meta: Meta<typeof Chart> = {
+    title: 'LinksMenu',
+    component: Chart,
+};
+
+export default meta;
+
+export const Demo: StoryObj<typeof Chart> = {
+    args: {
+        data: {
+            loading: false,
+            value: [
+                { x: 0, y: 10, z: 6 },
+                { x: 1, y: 12, z: 7 },
+                { x: 2, y: 8, z: 9 },
+                { x: 3, y: 13, z: 5 },
+            ],
+        },
+        options: {
+            labelColumn: 'x',
+            links: [],
+            series: [
+                {
+                    label: 'Green',
+                    type: ChartSeriesType.Line as const,
+                    valueColumn: 'y',
+                    tension: 0,
+                    borderColor: COLORS.green,
+                },
+                {
+                    label: 'Blue',
+                    type: ChartSeriesType.Line as const,
+                    valueColumn: 'z',
+                    tension: 0,
+                    borderColor: COLORS.blue,
+                },
+            ],
+            title: {
+                text: 'LinksMenu demo',
+            },
+            legend: {
+                display: true,
+            },
+        },
+    },
+    render: (args: React.ComponentProps<typeof Chart>) => <LinksMenuDemo {...args} />,
+};
+

--- a/packages/visualizations-react/stories/LinksMenu/LinksMenu.stories.tsx
+++ b/packages/visualizations-react/stories/LinksMenu/LinksMenu.stories.tsx
@@ -27,6 +27,7 @@ function LinksMenuDemo({ options, ...rest }: React.ComponentProps<typeof Chart>)
 
     const hrefPlainLabel = 'Open Code Library (href, no onClick callback)';
     const hrefTrackedLabel = 'Open Code Library (href, onClick tracking)';
+    const hrefDownloadLabel = 'Download example (href, download attr)';
     const actionLabel = 'Show message (action, window.alert)';
 
     const links: Link[] = [
@@ -41,6 +42,11 @@ function LinksMenuDemo({ options, ...rest }: React.ComponentProps<typeof Chart>)
                 setHrefTrackedClicks(c => c + 1);
                 addLog({ kind: 'href-tracked', label: hrefTrackedLabel, href: CODE_LIBRARY_HREF });
             },
+        },
+        {
+            href: '/favicon.ico',
+            label: hrefDownloadLabel,
+            download: 'custom-filename.ico',
         },
         {
             label: actionLabel,
@@ -229,6 +235,11 @@ function LinksMenuDemo({ options, ...rest }: React.ComponentProps<typeof Chart>)
                             </li>
                             <li>
                                 Optional <code style={inlineCode}>icon</code> on both shapes, SVG string
+                            </li>
+                            <li>
+                                Optional <code style={inlineCode}>download</code> on <strong>LinkHref</strong>, sets the
+                                anchor <code style={inlineCode}>download</code> attribute (honored by browsers for
+                                same-origin URLs only).
                             </li>
                         </ul>
 

--- a/packages/visualizations-react/test/LinksMenu.test.tsx
+++ b/packages/visualizations-react/test/LinksMenu.test.tsx
@@ -1,0 +1,155 @@
+// @jest-environment jsdom
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Link, LinkHref, LinkAction } from '@opendatasoft/visualizations';
+import { LinksMenu, LINKS_MENU_CLASS } from 'src';
+
+const hrefLink: LinkHref = {
+    href: 'https://example.com/export.csv',
+    label: 'Export by CSV',
+    download: 'My Asset - My Chart.csv',
+};
+
+const actionLink: LinkAction = {
+    onClick: () => {},
+    label: 'Export by PNG',
+};
+
+// The trigger button carries aria-label="Links" (see LinksMenu.svelte).
+const openMenu = async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Links' }));
+};
+
+describe('LinksMenu (reactified Svelte component)', () => {
+    describe('trigger + open/close', () => {
+        it('renders the trigger button and keeps the menu closed by default', () => {
+            const { container } = render(<LinksMenu links={[hrefLink]} />);
+            expect(screen.getByRole('button', { name: 'Links' })).toBeInTheDocument();
+            expect(container.querySelector('.dropdown')).toBeNull();
+        });
+
+        it('opens the menu on trigger click', async () => {
+            const { container } = render(<LinksMenu links={[hrefLink]} />);
+            await openMenu();
+            expect(container.querySelector('.dropdown')).toBeInTheDocument();
+        });
+
+        it('closes the menu on a second trigger click', async () => {
+            const { container } = render(<LinksMenu links={[hrefLink]} />);
+            await openMenu();
+            await openMenu();
+            await waitFor(() => expect(container.querySelector('.dropdown')).toBeNull());
+        });
+
+        it('exposes the root wrapper under LINKS_MENU_CLASS (filtered out of PNG captures)', () => {
+            const { container } = render(<LinksMenu links={[hrefLink]} />);
+            // Guards the divergence risk between the exported constant and the hardcoded
+            // class="links-menu" in the Svelte template (review point S2).
+            expect(container.querySelector(`.${LINKS_MENU_CLASS}`)).toBeInTheDocument();
+        });
+    });
+
+    describe('href items', () => {
+        it('renders an anchor with href, target, rel and download', async () => {
+            render(<LinksMenu links={[hrefLink]} />);
+            await openMenu();
+            const anchor = screen.getByRole('menuitem') as HTMLAnchorElement;
+            expect(anchor.tagName).toBe('A');
+            expect(anchor.getAttribute('href')).toBe('https://example.com/export.csv');
+            expect(anchor.getAttribute('target')).toBe('_blank');
+            expect(anchor.getAttribute('rel')).toContain('noopener');
+            expect(anchor.getAttribute('download')).toBe('My Asset - My Chart.csv');
+            expect(anchor).toHaveTextContent('Export by CSV');
+        });
+    });
+
+    describe('action items', () => {
+        it('renders a button, not an anchor', async () => {
+            render(<LinksMenu links={[actionLink]} />);
+            await openMenu();
+            const item = screen.getByRole('menuitem');
+            expect(item.tagName).toBe('BUTTON');
+            expect(screen.queryByRole('menuitem', { name: 'Export by PNG' })?.tagName).toBe('BUTTON');
+        });
+    });
+
+    describe('click behaviour', () => {
+        it('calls onClick and closes the menu when a href item is clicked', async () => {
+            const onClick = jest.fn();
+            const { container } = render(<LinksMenu links={[{ ...hrefLink, onClick }]} />);
+            await openMenu();
+            await userEvent.click(screen.getByRole('menuitem'));
+            expect(onClick).toHaveBeenCalledTimes(1);
+            await waitFor(() => expect(container.querySelector('.dropdown')).toBeNull());
+        });
+
+        it('calls onClick and closes the menu when an action item is clicked', async () => {
+            const onClick = jest.fn();
+            const { container } = render(<LinksMenu links={[{ ...actionLink, onClick }]} />);
+            await openMenu();
+            await userEvent.click(screen.getByRole('menuitem'));
+            expect(onClick).toHaveBeenCalledTimes(1);
+            await waitFor(() => expect(container.querySelector('.dropdown')).toBeNull());
+        });
+
+        it('still closes the menu when an action onClick throws (try/finally — review S3)', async () => {
+            const onClick = jest.fn(() => {
+                throw new Error('simulated export failure');
+            });
+            const { container } = render(<LinksMenu links={[{ ...actionLink, onClick }]} />);
+            await openMenu();
+            // The handler wraps onClick in try/finally: closeMenu() always runs even though the
+            // error is not swallowed (it re-throws after finally). jsdom surfaces that as a window
+            // "error" event, so we trap and preventDefault it for this dispatch, then assert the
+            // contract that matters: onClick ran and the menu closed despite the throw.
+            const swallow = (event: ErrorEvent) => event.preventDefault();
+            window.addEventListener('error', swallow);
+            try {
+                screen
+                    .getByRole('menuitem')
+                    .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+            } finally {
+                window.removeEventListener('error', swallow);
+            }
+            expect(onClick).toHaveBeenCalledTimes(1);
+            await waitFor(() => expect(container.querySelector('.dropdown')).toBeNull());
+        });
+    });
+
+    describe('dismissal', () => {
+        it('closes when clicking outside the menu', async () => {
+            const { container } = render(
+                <div>
+                    <button type="button" data-testid="outside">
+                        outside
+                    </button>
+                    <LinksMenu links={[hrefLink]} />
+                </div>,
+            );
+            await openMenu();
+            expect(container.querySelector('.dropdown')).toBeInTheDocument();
+            await userEvent.click(screen.getByTestId('outside'));
+            await waitFor(() => expect(container.querySelector('.dropdown')).toBeNull());
+        });
+
+        it('closes on Escape', async () => {
+            const { container } = render(<LinksMenu links={[hrefLink]} />);
+            await openMenu();
+            await userEvent.keyboard('{Escape}');
+            await waitFor(() => expect(container.querySelector('.dropdown')).toBeNull());
+        });
+    });
+
+    describe('mixed items', () => {
+        it('renders both href and action items in order', async () => {
+            const links: Link[] = [hrefLink, actionLink];
+            render(<LinksMenu links={links} />);
+            await openMenu();
+            const items = screen.getAllByRole('menuitem');
+            expect(items).toHaveLength(2);
+            expect(items[0].tagName).toBe('A');
+            expect(items[1].tagName).toBe('BUTTON');
+        });
+    });
+});

--- a/packages/visualizations-react/test/LinksMenu.test.tsx
+++ b/packages/visualizations-react/test/LinksMenu.test.tsx
@@ -44,8 +44,8 @@ describe('LinksMenu (reactified Svelte component)', () => {
 
         it('exposes the root wrapper under LINKS_MENU_CLASS (filtered out of PNG captures)', () => {
             const { container } = render(<LinksMenu links={[hrefLink]} />);
-            // Guards the divergence risk between the exported constant and the hardcoded
-            // class="links-menu" in the Svelte template (review point S2).
+            // Guards against divergence: LinksMenu.svelte applies LINKS_MENU_CLASS to its root,
+            // which consumers rely on to filter the menu out of PNG captures (review point S2).
             expect(container.querySelector(`.${LINKS_MENU_CLASS}`)).toBeInTheDocument();
         });
     });
@@ -70,7 +70,9 @@ describe('LinksMenu (reactified Svelte component)', () => {
             await openMenu();
             const item = screen.getByRole('menuitem');
             expect(item.tagName).toBe('BUTTON');
-            expect(screen.queryByRole('menuitem', { name: 'Export by PNG' })?.tagName).toBe('BUTTON');
+            expect(screen.queryByRole('menuitem', { name: 'Export by PNG' })?.tagName).toBe(
+                'BUTTON'
+            );
         });
     });
 
@@ -125,7 +127,7 @@ describe('LinksMenu (reactified Svelte component)', () => {
                         outside
                     </button>
                     <LinksMenu links={[hrefLink]} />
-                </div>,
+                </div>
             );
             await openMenu();
             expect(container.querySelector('.dropdown')).toBeInTheDocument();

--- a/packages/visualizations/CHANGELOG.md
+++ b/packages/visualizations/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.32.1-beta.1](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations@0.32.1-beta.0...@opendatasoft/visualizations@0.32.1-beta.1) (2026-04-17)
+
+**Note:** Version bump only for package @opendatasoft/visualizations
+
+
+
+
+
 ## [0.32.1-beta.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations@0.32.0...@opendatasoft/visualizations@0.32.1-beta.0) (2026-04-16)
 
 

--- a/packages/visualizations/CHANGELOG.md
+++ b/packages/visualizations/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.32.1-beta.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations@0.32.0...@opendatasoft/visualizations@0.32.1-beta.0) (2026-04-16)
+
+
+### Features
+
+* support action items and href onClick ([d794795](https://github.com/opendatasoft/ods-dataviz-sdk/commit/d79479599d892d005be8245f1f47a57e59fea8c2))
+
+
+
+
+
 # [0.32.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations@0.30.0...@opendatasoft/visualizations@0.32.0) (2026-04-08)
 
 

--- a/packages/visualizations/CHANGELOG.md
+++ b/packages/visualizations/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.33.0-beta.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations@0.32.1...@opendatasoft/visualizations@0.33.0-beta.0) (2026-05-26)
+
+
+### Features
+
+* **LinksMenu:** add optional download attribute on LinkHref ([16ad99d](https://github.com/opendatasoft/ods-dataviz-sdk/commit/16ad99da608cc3c6411d2c082ef76f81cc00148c))
+* support action items and href onClick ([d794795](https://github.com/opendatasoft/ods-dataviz-sdk/commit/d79479599d892d005be8245f1f47a57e59fea8c2))
+
+
+
+
+
 ## [0.32.1](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations@0.32.0...@opendatasoft/visualizations@0.32.1) (2026-05-25)
 
 

--- a/packages/visualizations/CHANGELOG.md
+++ b/packages/visualizations/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.33.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations@0.33.0-beta.0...@opendatasoft/visualizations@0.33.0) (2026-06-16)
+
+
+### Bug Fixes
+
+* **LinksMenu:** address review (font-size, close-on-error, class constant, onClick doc) ([b9ffe28](https://github.com/opendatasoft/ods-dataviz-sdk/commit/b9ffe2803dbd0467b4510846c3fda8511fb24f14))
+
+
+
+
+
 # [0.33.0-beta.0](https://github.com/opendatasoft/ods-dataviz-sdk/compare/@opendatasoft/visualizations@0.32.1...@opendatasoft/visualizations@0.33.0-beta.0) (2026-05-26)
 
 

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations",
-    "version": "0.32.1-beta.0",
+    "version": "0.32.1-beta.1",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations",
-    "version": "0.32.0",
+    "version": "0.32.1-beta.0",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations",
-    "version": "0.32.1",
+    "version": "0.33.0-beta.0",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opendatasoft/visualizations",
-    "version": "0.33.0-beta.0",
+    "version": "0.33.0",
     "license": "MIT",
     "author": "opendatasoft",
     "homepage": "https://github.com/opendatasoft/ods-dataviz-sdk",

--- a/packages/visualizations/src/components/utils/LinksMenu.svelte
+++ b/packages/visualizations/src/components/utils/LinksMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onDestroy, tick } from 'svelte';
     import type { LinksMenuProps } from 'types';
+    import { isLinkHref } from 'types';
 
     // Ensure exported type matches declared props
     type $$Props = LinksMenuProps;
@@ -10,7 +11,7 @@
 
     let menuElement: HTMLDivElement;
     let buttonElement: HTMLButtonElement;
-    let menuItemElements: HTMLAnchorElement[] = [];
+    let menuItemElements: (HTMLElement | undefined)[] = [];
     let isOpen = false;
     let focusedIndex = -1;
 
@@ -38,6 +39,11 @@
         } else {
             openMenu();
         }
+    }
+
+    function handleMenuItemClick(link: $$Props['links'][number]) {
+        link.onClick?.();
+        closeMenu();
     }
 
     function focusItem(index: number) {
@@ -173,23 +179,41 @@
             on:keydown={handleMenuKeydown}
         >
             {#each links as link, index}
-                <a
-                    bind:this={menuItemElements[index]}
-                    href={link.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="dropdown-item"
-                    role="menuitem"
-                    tabindex={focusedIndex === index ? 0 : -1}
-                    on:click={() => closeMenu()}
-                >
-                    {#if link.icon}
-                        <span class="dropdown-item-icon" aria-hidden="true">
-                            {@html link.icon}
-                        </span>
-                    {/if}
-                    <span class="dropdown-item-label">{link.label}</span>
-                </a>
+                {#if isLinkHref(link)}
+                    <a
+                        bind:this={menuItemElements[index]}
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="dropdown-item"
+                        role="menuitem"
+                        tabindex={focusedIndex === index ? 0 : -1}
+                        on:click={() => handleMenuItemClick(link)}
+                    >
+                        {#if link.icon}
+                            <span class="dropdown-item-icon" aria-hidden="true">
+                                {@html link.icon}
+                            </span>
+                        {/if}
+                        <span class="dropdown-item-label">{link.label}</span>
+                    </a>
+                {:else}
+                    <button
+                        bind:this={menuItemElements[index]}
+                        type="button"
+                        class="dropdown-item dropdown-item--action"
+                        role="menuitem"
+                        tabindex={focusedIndex === index ? 0 : -1}
+                        on:click={() => handleMenuItemClick(link)}
+                    >
+                        {#if link.icon}
+                            <span class="dropdown-item-icon" aria-hidden="true">
+                                {@html link.icon}
+                            </span>
+                        {/if}
+                        <span class="dropdown-item-label">{link.label}</span>
+                    </button>
+                {/if}
             {/each}
         </div>
     {/if}
@@ -288,5 +312,18 @@
 
     .dropdown-item-label {
         flex: 1;
+    }
+
+    /* Action items: reset native button chrome to match anchor menu items */
+    button.dropdown-item--action {
+        width: 100%;
+        margin: 0;
+        border: none;
+        background: transparent;
+        font: inherit;
+        text-align: left;
+        cursor: pointer;
+        appearance: none;
+        -webkit-appearance: none;
     }
 </style>

--- a/packages/visualizations/src/components/utils/LinksMenu.svelte
+++ b/packages/visualizations/src/components/utils/LinksMenu.svelte
@@ -185,6 +185,7 @@
                         href={link.href}
                         target="_blank"
                         rel="noopener noreferrer"
+                        download={link.download || null}
                         class="dropdown-item"
                         role="menuitem"
                         tabindex={focusedIndex === index ? 0 : -1}

--- a/packages/visualizations/src/components/utils/LinksMenu.svelte
+++ b/packages/visualizations/src/components/utils/LinksMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { onDestroy, tick } from 'svelte';
     import type { LinksMenuProps } from 'types';
-    import { isLinkHref } from 'types';
+    import { isLinkHref, LINKS_MENU_CLASS } from 'types';
 
     // Ensure exported type matches declared props
     type $$Props = LinksMenuProps;
@@ -42,8 +42,11 @@
     }
 
     function handleMenuItemClick(link: $$Props['links'][number]) {
-        link.onClick?.();
-        closeMenu();
+        try {
+            link.onClick?.();
+        } finally {
+            closeMenu();
+        }
     }
 
     function focusItem(index: number) {
@@ -143,7 +146,7 @@
     });
 </script>
 
-<div bind:this={menuElement} class="links-menu" {style}>
+<div bind:this={menuElement} class={LINKS_MENU_CLASS} {style}>
     <button
         bind:this={buttonElement}
         class="links-button"
@@ -321,7 +324,9 @@
         margin: 0;
         border: none;
         background: transparent;
-        font: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
         text-align: left;
         cursor: pointer;
         appearance: none;

--- a/packages/visualizations/src/types.ts
+++ b/packages/visualizations/src/types.ts
@@ -6,17 +6,37 @@ export type DataFrame = Record<string, any>[];
 export type Color = string;
 
 /**
- * Represents a link in the LinksMenu component.
- * Can be extended in the future to support other link types (e.g., callbacks, exports).
+ * Opens in a new tab when clicked (standard anchor behaviour).
  */
-export interface Link {
-    /** The URL to navigate to when the link is clicked */
+export interface LinkHref {
     href: string;
-    /** The label displayed for this link */
     label: string;
     /** Optional SVG string to display as an icon next to the label */
     icon?: string;
+    /** Optional click callback invoked before opening the href. */
+    onClick?: () => void;
 }
+
+/**
+ * Runs a client-side callback. Renders as a menu button, not an anchor.
+ */
+export interface LinkAction {
+    onClick: () => void;
+    label: string;
+    icon?: string;
+}
+
+/**
+ * Menu item in LinksMenu: either a navigational link or an action.
+ */
+export type Link = LinkHref | LinkAction;
+
+export function isLinkHref(link: Link): link is LinkHref {
+    return 'href' in link;
+}
+
+/** Root CSS class of the LinksMenu wrapper. Consumers can use this to filter the menu from DOM clones (e.g. image export). */
+export const LINKS_MENU_CLASS = 'links-menu';
 
 /**
  * Props for the LinksMenu component.

--- a/packages/visualizations/src/types.ts
+++ b/packages/visualizations/src/types.ts
@@ -15,6 +15,12 @@ export interface LinkHref {
     icon?: string;
     /** Optional click callback invoked before opening the href. */
     onClick?: () => void;
+    /**
+     * Optional filename hint passed to the browser as the `download` attribute on the anchor.
+     * Browsers honor this for same-origin URLs (cross-origin downloads ignore it and fall back
+     * to the server-provided filename).
+     */
+    download?: string;
 }
 
 /**

--- a/packages/visualizations/src/types.ts
+++ b/packages/visualizations/src/types.ts
@@ -13,7 +13,7 @@ export interface LinkHref {
     label: string;
     /** Optional SVG string to display as an icon next to the label */
     icon?: string;
-    /** Optional click callback invoked before opening the href. */
+    /** Optional side-effect callback invoked before the href is followed. Does not intercept or prevent navigation. */
     onClick?: () => void;
     /**
      * Optional filename hint passed to the browser as the `download` attribute on the anchor.
@@ -41,7 +41,12 @@ export function isLinkHref(link: Link): link is LinkHref {
     return 'href' in link;
 }
 
-/** Root CSS class of the LinksMenu wrapper. Consumers can use this to filter the menu from DOM clones (e.g. image export). */
+/**
+ * Root CSS class of the LinksMenu wrapper. Consumers can use this to filter the menu from DOM
+ * clones (e.g. image export). LinksMenu.svelte applies it via `class={LINKS_MENU_CLASS}`, so the
+ * single source of truth is this constant (scoped CSS still matches via the `.links-menu` rule in
+ * the component's <style>).
+ */
 export const LINKS_MENU_CLASS = 'links-menu';
 
 /**


### PR DESCRIPTION
## Summary

`LinksMenu` now supports both navigational links and client-side actions in the same menu, with an optional click hook and download filename hint on links.

Internal context, [sc-59779](https://app.shortcut.com/opendatasoft/story/59779).

## Public API

`Link` is a discriminated union, `LinkHref | LinkAction`.

`LinkHref` renders `<a target="_blank" rel="noopener noreferrer">`:
- `href`, `label`, `icon?`
- `onClick?`, called before navigation (analytics on downloads)
- `download?`, hint for the browser's `download` attribute (same-origin only)

`LinkAction` renders `<button type="button">`:
- `onClick`, `label`, `icon?`

Helpers exported, `isLinkHref(link)` type guard, `LINKS_MENU_CLASS` constant (CSS root, lets consumers exclude the menu from DOM screenshots).

## Changelog

Feature, `LinksMenu` accepts action items alongside href links, with optional `onClick` and `download` on href links.

## Test plan

- One href link with an `onClick` spy, click it, expect spy called and menu closed
- One action item, click it, expect callback called and menu closed
- One href link with a `download` string, click it, browser uses the hint as filename (same-origin URL)
