### PR TITLE
fix(Table): Screen-reader visible header for actions columm

### DIFF
--- a/packages/visualizations/rollup.config.mjs
+++ b/packages/visualizations/rollup.config.mjs
@@ -2,7 +2,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import svelte from 'rollup-plugin-svelte';
 import alias from '@rollup/plugin-alias';
-import autoPreprocess from 'svelte-preprocess';
+import svelteConfig from './svelte.config.mjs';
 import postcss from 'rollup-plugin-postcss';
 import autoprefixer from 'autoprefixer';
 // import visualizer from 'rollup-plugin-visualizer';
@@ -38,11 +38,7 @@ function basePlugins() {
                 dev: !production,
                 immutable: true,
             },
-            preprocess: autoPreprocess({
-                scss: {
-                    includePaths: ['src'],
-                },
-            }),
+            preprocess: svelteConfig.preprocess,
         }),
         typescript({
             sourceMap: true,

--- a/packages/visualizations/src/components/Table/Headers/Th.svelte
+++ b/packages/visualizations/src/components/Table/Headers/Th.svelte
@@ -58,12 +58,14 @@
             scrolled: $isHorizontallyScrolled,
             lastStickyColumn: $lastStickyColumn,
         })}`}
-        aria-label={extraButtonColumnLabel}
-    />
+    >
+        <span class="sr-only">{extraButtonColumnLabel}</span>
+    </th>
 {/if}
 
 <style lang="scss">
     @import '../sticky';
+    @import 'styles/accessibility';
     :global(.ods-dataviz--default th) {
         text-align: left;
         padding: var(--spacing-75);

--- a/packages/visualizations/src/styles/_accessibility.scss
+++ b/packages/visualizations/src/styles/_accessibility.scss
@@ -1,0 +1,16 @@
+/*
+    Sets an element to be "screen reader only" so that it is not visible at all to usual browsers,
+    but visible to screen readers in a relevant place in the DOM.
+    It relies on various ways to "hide" a text without using `display` or `visibility` which would hide them from screen
+    readers as well.
+
+    Source: https://webaim.org/techniques/css/invisiblecontent/
+ */
+.sr-only {
+    position: absolute;
+    inset-inline-start: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}

--- a/packages/visualizations/svelte.config.mjs
+++ b/packages/visualizations/svelte.config.mjs
@@ -1,0 +1,9 @@
+import autoPreprocess from 'svelte-preprocess';
+
+export default {
+    preprocess: autoPreprocess({
+        scss: {
+            includePaths: ['src'],
+        },
+    }),
+};


### PR DESCRIPTION
## Summary

The goal for this PR is to fix accessibility labels for the "actions" column of the Table component.

(Internal for Opendatasoft only) Associated Shortcut ticket: [sc-61551](https://app.shortcut.com/opendatasoft/story/61551).

### Changes
As described in the story, using aria-label is not a recommended practice, so I got back to the usual `sr-only`. Alternatively we could even display the header itself for real, but it's a design discussion we can have later.

It felt like a good idea to make an utility class shared across the code, so I made one. However, in order to have a clean import (`styles/accessibility`), I had to make sure CSS imports were resolved against `src` both in rollup (for build), and in svelte config (for svelte-check), so it pulled a bit more changes. If it feels a bit too much, we could always have imports like `../../../styles/accessibility` which is not that much of a problem, considering a mistake would be caught immediately.


## To be tested
The `th` for the actions column now has a real label hidden for browser but not for screen readers, instead of an aria-label.

## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
