### PR TITLE
feat(api-client): Remove fromNetwork, add assets endpoints

### DIFF
--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -143,12 +143,10 @@ Start with one of the following entry points:
 
 -   `fromMonitoring()`: access monitoring datasets
 
--   `fromDataNetwork()`: access any datasets on [Opendatasoft's data network](https://data.opendatasoft.com/)
-
 From there, your IDE should provide autocompletion.
 
 ```javascript
-import { ApiClient, fromCatalog, fromDataNetwork, fromMonitoring } from '@opendatasoft/api-client';
+import { ApiClient, fromCatalog, fromMonitoring } from '@opendatasoft/api-client';
 
 const client = new ApiClient({
     interceptRequest: async request => {
@@ -163,14 +161,6 @@ client.get(fromMonitoring().itself());
 // ../catalog/datasets/
 client.get(fromCatalog().datasets());
 
-// ../opendatasoft/datasets/sirene@data/facets/?lang=fr
-client.get(
-    fromDataNetwork()
-        .dataset('sirene@data')
-        .facets()
-        .lang('fr')
-);
-
 // ../catalog/datasets/?select=dataset_id%2C+records_count
 client.get(
     fromCatalog()
@@ -184,6 +174,13 @@ client.get(
         .dataset('my-dataset')
         .record('2ee92a48178f784a5babfc06cb42d210cab57f55')
 );
+
+// ../catalog/assets/my-asset/
+client.get(
+    fromCatalog()
+      .asset('my-asset')
+      .itself()
+)
 ```
 
 The `Query` interface expose convenient parameters of an API request.
@@ -265,7 +262,6 @@ Here are some samples to get you started.
 
 
 -   [Opendatasoft's APIv2.1 documentation](https://help.opendatasoft.com/apis/ods-explore-v2/explore_v2.1.html)
--   [Data Network API Console](https://data.opendatasoft.com/api/explore/v2.1/console)
 
 ## Contributing
 

--- a/packages/api-client/src/odsql/index.ts
+++ b/packages/api-client/src/odsql/index.ts
@@ -157,14 +157,22 @@ function root(source: string) {
             record: (recordId: string) =>
                 new Query(`${source}/datasets/${datasetId}/records/${recordId}/`),
         }),
+        /**
+         * FIXME: Update this URL or remove this comment when these endpoints are out of beta.
+         * The assets endpoints are still in development and not yet documented.
+         * Therefore, these URLs may change in the future.
+         */
+        asset: (slug: string) => ({
+            itself: () => new Query(`${source}/assets/${slug}/`),
+            facets: () => new Query(`${source}/assets/${slug}/facets/`),
+            records: () => new Query(`${source}/assets/${slug}/records/`),
+        }),
     });
 }
 
 export const fromCatalog = root('catalog');
 
 export const fromMonitoring = root('monitoring');
-
-export const fromDataNetwork = root('opendatasoft');
 
 export const field = (fieldName: string) => `\`${fieldName.replace(/`/g, '\\`')}\``;
 

--- a/packages/api-client/test/odsql.test.ts
+++ b/packages/api-client/test/odsql.test.ts
@@ -5,7 +5,6 @@
 import { expect, it, describe, test } from '@jest/globals';
 import {
     fromCatalog,
-    fromDataNetwork,
     fromMonitoring,
     Query,
     field,
@@ -43,13 +42,9 @@ describe('ODSQL query builder', () => {
 
             expect(fromMonitoring().itself().toString()).toEqual('monitoring/');
 
-            expect(fromDataNetwork().dataset('sirene@data').facets().lang('fr').toString()).toEqual(
-                'opendatasoft/datasets/sirene@data/facets/?lang=fr'
+            expect(fromCatalog().asset('my-asset').itself().toString()).toEqual(
+                'catalog/assets/my-asset/'
             );
-
-            expect(
-                fromDataNetwork().dataset('sirene@data').records().lang('fr').toString()
-            ).toEqual('opendatasoft/datasets/sirene@data/records/?lang=fr');
         });
 
         test('get a record', () => {


### PR DESCRIPTION
## Summary

The goal for this PR is to add new assets endpoints to the API Client. These are technically still in beta and may change at a later time with breaking changes.

### Changes
- Remove `fromNetwork` which is no longer supported on the platform itself, and unused by our own code
- Added new endpoints for assets:
  - Asset lookup
  - Facets
  - Records

#### Breaking Changes
`fromNetwork` is no longer officially supported for external applications, so removing it from the public API Client seems a good idea.

### Changelog
We removed the deprecated `fromNetwork` source for queries.
We also added new endpoints for assets. Note that these endpoints are still in beta and may change with no warning ahead.


## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
