### PR TITLE
feat(Map): Add onMapReady callback to transmit the map instance

### DIFF
--- a/packages/visualizations/src/components/Map/WebGl/WebGl.svelte
+++ b/packages/visualizations/src/components/Map/WebGl/WebGl.svelte
@@ -55,6 +55,7 @@
     $: map.jumpTo(getCenterZoomOptions({ zoom, center: $center }));
     $: map.loadImages(images);
     $: map.updateClickHandler(options?.onFeatureClick);
+    $: map.updateMapReadyHandler(options?.onMapReady);
 
     // Lifecycle
     onMount(() => {

--- a/packages/visualizations/src/components/Map/WebGl/WebGl.ts
+++ b/packages/visualizations/src/components/Map/WebGl/WebGl.ts
@@ -125,6 +125,9 @@ export default class MapPOI {
     /** Additional custom click handler */
     private onFeatureClick: OnFeatureClick | null = null;
 
+    /** Callback invoked with the MapLibre map instance once it is ready */
+    private onMapReady: ((map: Map) => void) | null = null;
+
     /** To queue functions that depend on map readiness. Will be executed when the card is ready. */
     private queue(fn: MapFunction) {
         if (this.isReady && this.map) return fn(this.map);
@@ -569,6 +572,7 @@ export default class MapPOI {
                 // Store base style after the first load
                 this.baseStyle = this.map.getStyle();
                 this.enqueue(this.map);
+                this.onMapReady?.(this.map);
             }
         });
     }
@@ -646,6 +650,10 @@ export default class MapPOI {
         if (handler) {
             this.onFeatureClick = handler;
         }
+    }
+
+    updateMapReadyHandler(handler?: (map: Map) => void) {
+        this.onMapReady = handler ?? null;
     }
 
     /**

--- a/packages/visualizations/src/components/Map/WebGl/types.ts
+++ b/packages/visualizations/src/components/Map/WebGl/types.ts
@@ -4,6 +4,7 @@ import type {
     GeoJSONFeature,
     GestureOptions,
     LngLatLike,
+    Map as MaplibreMap,
     MapGeoJSONFeature,
     RequestTransformFunction,
     StyleImageMetadata,
@@ -59,8 +60,10 @@ export interface WebGlMapOptions {
     preserveDrawingBuffer?: boolean;
     /** Images to load by the Map. keys are image ids  */
     images?: Images;
-    /** An addiational callback to be triggered when clicking a feature */
+    /** An additional callback to be triggered when clicking a feature */
     onFeatureClick?: OnFeatureClick;
+    /** A callback called with the MapLibre map instance once the map has loaded and is ready */
+    onMapReady?: (map: MaplibreMap) => void;
 }
 
 export type WebGlMapStyleOption = Partial<Pick<StyleSpecification, 'sources' | 'layers'>>;


### PR DESCRIPTION
## Summary

The goal for this PR is to expose the Map instance to calling code, to open for more customization.

### Changes
- Add an optional `onMapReady` option, which can be used by the calling code to get the `Map` instance when it is ready. It can then be used to add event hooks, use directly some Maplibre methods, etc.

There is already a lot of Maplibre exposed through the `WebGlMap` component, such as the layers/source configuration, so I think it makes sense, and leaves the component as a "supercharged Maplibre".

It is used in a platform PR mentioned in the feed below.

## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
