### PR TITLE
feat: chart can now use maintainAspectRatio false to fill the container

### DIFF
--- a/packages/visualizations-react/stories/Chart/AspectRatio.stories.tsx
+++ b/packages/visualizations-react/stories/Chart/AspectRatio.stories.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import type { ChartOptions, DataFrame } from '@opendatasoft/visualizations';
+import { ChartSeriesType } from '@opendatasoft/visualizations';
+import { Meta, StoryObj } from '@storybook/react';
+import type { Props } from 'reactify';
+import { Chart } from 'src';
+import { COLORS, defaultLinks } from '../utils';
+
+/**
+ * By default the chart keeps a fixed `aspectRatio` (a numeric width/height ratio) and derives its
+ * height from its width. Setting `aspectRatio: 'auto'` drops that constraint and lets ChartJS size
+ * the canvas from the parent's box instead, which requires the parent to have an explicit height.
+ *
+ * Drag the bottom-right corner of either box below: the `'auto'` chart follows both dimensions,
+ * while the fixed one keeps its ratio and letterboxes inside the leftover space.
+ */
+const meta: Meta = {
+    title: 'Chart/AspectRatio',
+};
+
+export default meta;
+
+/**
+ * Resizable host with an explicit height, which `aspectRatio: 'auto'` needs to fill. The shared
+ * ChartTemplate can't be reused here: it sets a width but leaves the height to the content.
+ *
+ * The box starts tall enough for the fixed-ratio chart to fit, so what you see when resizing is the
+ * ratio behaviour rather than a scrollbar. `overflow: hidden` (still resizable) also absorbs the
+ * couple of pixels a content-box card overflows its container by.
+ */
+const ResizableChartTemplate = (args: Props<DataFrame, ChartOptions>) => (
+    <div
+        style={{
+            resize: 'both',
+            overflow: 'hidden',
+            height: '440px',
+            width: '520px',
+            border: '1px dashed grey',
+        }}
+    >
+        <Chart {...args} />
+    </div>
+);
+
+const df = [
+    { x: 'Jan', y: 12 },
+    { x: 'Feb', y: 19 },
+    { x: 'Mar', y: 8 },
+    { x: 'Apr', y: 24 },
+    { x: 'May', y: 17 },
+    { x: 'Jun', y: 21 },
+];
+
+const AutoAspectRatioArgs: Props<DataFrame, ChartOptions> = {
+    data: {
+        loading: false,
+        value: df,
+    },
+    options: {
+        labelColumn: 'x',
+        links: defaultLinks,
+        aspectRatio: 'auto',
+        series: [
+            {
+                type: ChartSeriesType.Bar,
+                valueColumn: 'y',
+                backgroundColor: COLORS.blue,
+            },
+        ],
+        title: {
+            text: "aspectRatio: 'auto' — fills its resizable parent",
+        },
+    },
+};
+
+export const AutoAspectRatio: StoryObj<typeof ResizableChartTemplate> = {
+    args: AutoAspectRatioArgs,
+    render: args => <ResizableChartTemplate {...args} />,
+};
+
+const FixedAspectRatioArgs: Props<DataFrame, ChartOptions> = {
+    ...AutoAspectRatioArgs,
+    options: {
+        ...AutoAspectRatioArgs.options,
+        aspectRatio: 4 / 3,
+        title: {
+            text: 'aspectRatio: 4/3 (default) — keeps its ratio, letterboxes',
+        },
+    },
+};
+
+export const FixedAspectRatio: StoryObj<typeof ResizableChartTemplate> = {
+    args: FixedAspectRatioArgs,
+    render: args => <ResizableChartTemplate {...args} />,
+};

--- a/packages/visualizations/src/components/Chart/Chart.svelte
+++ b/packages/visualizations/src/components/Chart/Chart.svelte
@@ -73,10 +73,15 @@
     let dataFrame: DataFrame = [];
     let series: ChartSeries[] = [];
     let { labelColumn } = options;
+    let isAutoAspectRatio: boolean;
+    let numericAspectRatio: number;
 
     $: dataFrame = data.value || [];
     $: series = options.series;
     $: labelColumn = options.labelColumn;
+    $: isAutoAspectRatio = options.aspectRatio === 'auto';
+    // Single source of truth for the fixed-ratio default, used by both the CSS box and ChartJS.
+    $: numericAspectRatio = typeof options.aspectRatio === 'number' ? options.aspectRatio : 4 / 3;
 
     $: chartConfig = update(chartConfig, {
         type: { $set: defaultValue(options.series[0]?.type, ChartSeriesType.Line) },
@@ -87,7 +92,16 @@
         /* Kills ChartJS legend if in custom mode
          * To be deleted when fully switching to home made one */
         const legend = options.legend?.custom ? { display: false } : buildLegend(options);
-        chartOptions.aspectRatio = defaultValue(options.aspectRatio, 4 / 3);
+        if (isAutoAspectRatio) {
+            // Let ChartJS size the canvas from its parent box instead of a fixed ratio
+            chartOptions.aspectRatio = undefined;
+            chartOptions.maintainAspectRatio = false;
+        } else {
+            chartOptions.aspectRatio = numericAspectRatio;
+            // Both branches assign explicitly: chartConfig.options is mutated in place across
+            // renders, so an omitted key would keep the previous mode's value.
+            chartOptions.maintainAspectRatio = true;
+        }
         chartOptions.scales = buildScales(options, dataFrame);
         chartOptions.layout = {
             padding: defaultValue(options?.padding, 12),
@@ -239,10 +253,12 @@
         subtitle={displaySubtitle ? options.subtitle?.text : undefined}
         links={options.links}
         className="container"
+        fill={isAutoAspectRatio}
     >
         <figure
             class="chart legend--{legendPosition}"
-            style="--aspect-ratio: {defaultValue(options.aspectRatio, 4 / 3)}"
+            class:fill={isAutoAspectRatio}
+            style="--aspect-ratio: {isAutoAspectRatio ? 'auto' : numericAspectRatio}"
         >
             <!-- svelte-ignore a11y-no-interactive-element-to-noninteractive-role -->
             <canvas
@@ -269,7 +285,21 @@
         flex-grow: 1;
         margin: 0;
         display: flex;
-        aspect-ratio: var(--aspect-ratio);
+        aspect-ratio: var(--aspect-ratio, auto);
+    }
+    /* No ratio to honour, so take the space the card leaves us. `flex-basis: 0` rather than `auto`
+     * (or `height: 100%`) is what makes this purely free-space driven: the figure never derives its
+     * size from the canvas ChartJS just sized, so shrinking the container can't be fought by the
+     * canvas it produced. `min-height: 0` lifts the flex item's automatic minimum so it can shrink
+     * below that canvas. Scoped to this modifier so the fixed-ratio mode keeps sizing from
+     * `aspect-ratio`, which only applies while one axis stays `auto`. */
+    figure.fill {
+        flex: 1 1 0;
+        min-height: 0;
+    }
+    figure.fill canvas {
+        min-width: 0;
+        min-height: 0;
     }
     .legend--bottom {
         flex-direction: column;

--- a/packages/visualizations/src/components/Chart/types.ts
+++ b/packages/visualizations/src/components/Chart/types.ts
@@ -6,8 +6,11 @@ export interface ChartOptions {
     labelColumn?: string;
     /** Series to display */
     series: ChartSeries[];
-    /** Chart aspect ratio */
-    aspectRatio?: number;
+    /**
+     * Chart aspect ratio: a number for a fixed width/height ratio (default 4/3), or `'auto'` to fill
+     * the parent's box instead. `'auto'` needs an explicit height on the parent chain.
+     */
+    aspectRatio?: number | 'auto';
     /** Chart padding */
     padding?:
         | number

--- a/packages/visualizations/src/components/utils/Card.svelte
+++ b/packages/visualizations/src/components/utils/Card.svelte
@@ -13,6 +13,7 @@
     export let className: $$Props['className'] = null;
     export let clientWidth: $$Props['clientWidth'];
     export let tag: $$Props['tag'] = 'div';
+    export let fill: $$Props['fill'] = false;
 </script>
 
 <svelte:element
@@ -20,6 +21,7 @@
     bind:clientWidth
     class="card {className || ''}"
     class:ods-dataviz--default={defaultStyle}
+    class:ods-dataviz--fill={fill}
     {style}
 >
     {#if title || subtitle || links}
@@ -60,6 +62,15 @@
     }
     .card.ods-dataviz--default {
         flex-wrap: wrap;
+    }
+    /* Take the height the parent gives us instead of the content's. `box-sizing` keeps padding and
+     * border inside that height, and `nowrap` stops a full-height slot from wrapping onto a second
+     * flex column. Declared after `--default` so both win over it, and scoped to this modifier so
+     * content-sized cards keep their current geometry. */
+    .card.ods-dataviz--fill {
+        box-sizing: border-box;
+        height: 100%;
+        flex-wrap: nowrap;
     }
     h3,
     p {

--- a/packages/visualizations/src/types.ts
+++ b/packages/visualizations/src/types.ts
@@ -68,6 +68,8 @@ export interface CardProps extends Record<string, unknown> {
     className?: string | null;
     clientWidth?: number;
     tag?: 'div' | 'figure';
+    /** Fill the parent's height instead of being sized by the content */
+    fill?: boolean;
 }
 
 export interface DataBounds {


### PR DESCRIPTION
## Summary

The goal for this PR is to make chart use maintainAspectRatio false to fill the container.

## Review checklist

- [ ] Description is complete
- [ ] Commits respect the [Conventional Commits Specification](https://github.com/opendatasoft/ods-dataviz-sdk/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] 2 reviewers (1 if trivial)
- [ ] Tests coverage has improved
- [ ] Code is ready for a release on NPM
